### PR TITLE
Only display active managers when requesting a review

### DIFF
--- a/ComplaintTracking/DAL/DAL.Users.cs
+++ b/ComplaintTracking/DAL/DAL.Users.cs
@@ -62,7 +62,8 @@ namespace ComplaintTracking
         public async Task<SelectList> GetUsersInRoleSelectListAsync(CtsRole ctsRole, Guid? officeId = null)
         {
             var users = (await _userManager.GetUsersInRoleAsync(ctsRole.ToString()))
-                .Where(e => officeId == null || e.OfficeId == officeId);
+                .Where(e => (officeId == null || e.OfficeId == officeId) && e.Active)
+                .OrderBy(e => e.SortableFullName);
             return new SelectList(users, nameof(ApplicationUser.Id), nameof(ApplicationUser.SortableFullName));
         }
     }


### PR DESCRIPTION
Reported by the program via Zendesk.

Previously, inactive accounts were included in the list. Also sorts the list alphabetically.
