### PR TITLE
Consolidate code for alert messages

### DIFF
--- a/src/WebApp/Pages/Account/Index.cshtml
+++ b/src/WebApp/Pages/Account/Index.cshtml
@@ -7,7 +7,6 @@
 
 <h1>@ViewData["Title"]</h1>
 <hr />
-<partial name="_AlertPartial" for="Message" />
 
 <h2>@Html.DisplayFor(m => m.DisplayStaff.Name, TemplateNames.StringOrNone)</h2>
 

--- a/src/WebApp/Pages/Account/Index.cshtml.cs
+++ b/src/WebApp/Pages/Account/Index.cshtml.cs
@@ -1,7 +1,5 @@
 using Cts.AppServices.Staff;
 using Cts.Domain.Identity;
-using Cts.WebApp.Platform.Models;
-using Cts.WebApp.Platform.PageModelHelpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -14,7 +12,6 @@ public class IndexModel : PageModel
     public StaffViewDto DisplayStaff { get; private set; } = default!;
     public string? OfficeName => DisplayStaff.Office?.Name;
     public IList<AppRole> Roles { get; private set; } = default!;
-    public DisplayMessage? Message { get; private set; }
 
     public async Task<IActionResult> OnGetAsync([FromServices] IStaffAppService staffService)
     {
@@ -23,7 +20,6 @@ public class IndexModel : PageModel
 
         DisplayStaff = staff;
         Roles = await staffService.GetAppRolesAsync(DisplayStaff.Id);
-        Message = TempData.GetDisplayMessage();
 
         return Page();
     }

--- a/src/WebApp/Pages/Account/Login.cshtml
+++ b/src/WebApp/Pages/Account/Login.cshtml
@@ -11,8 +11,6 @@
     State of Georgia employees only.
 </p>
 
-<partial name="_AlertPartial" for="Message" />
-
 <div class="p-5 bg-light border rounded-3 mt-5 mb-5">
     <h1 class="display-4">Sign in using your work account</h1>
 

--- a/src/WebApp/Pages/Account/Login.cshtml.cs
+++ b/src/WebApp/Pages/Account/Login.cshtml.cs
@@ -1,6 +1,4 @@
-﻿using Cts.WebApp.Platform.Models;
-using Cts.WebApp.Platform.PageModelHelpers;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -10,16 +8,13 @@ namespace Cts.WebApp.Pages.Account;
 public class LoginModel : PageModel
 {
     public string? ReturnUrl { get; private set; }
-    public DisplayMessage? Message { get; private set; }
 
     public IActionResult OnGet(string? returnUrl = null)
     {
-        if (User.Identity?.IsAuthenticated ?? false) 
+        if (User.Identity?.IsAuthenticated ?? false)
             return string.IsNullOrEmpty(returnUrl) ? RedirectToPage("/Index") : LocalRedirect(returnUrl);
-            
-        ReturnUrl = returnUrl;
 
-        Message = TempData.GetDisplayMessage();
+        ReturnUrl = returnUrl;
         return Page();
     }
 }

--- a/src/WebApp/Pages/Admin/Complaints/Details.cshtml
+++ b/src/WebApp/Pages/Admin/Complaints/Details.cshtml
@@ -5,6 +5,7 @@
 @model DetailsModel
 @{
     ViewData["Title"] = $"Complaint ID {Model.Item.Id}";
+    var alertClass = Model.Item.ComplaintClosed ? "alert-secondary" : "alert-info";
 }
 
 @* Remove when complaint actions have all been implemented: *@
@@ -14,14 +15,14 @@
 
 @if (Model.UserCan[ComplaintOperation.ViewAsOwner])
 {
-    <p>
+    <div class="alert @alertClass" role="alert">
         This Complaint was assigned to you on @Html.DisplayFor(m => m.Item.CurrentOwnerAssignedDate, TemplateNames.LongDateTimeOrNotEntered).
         @if (Model.Item.CurrentOwnerAcceptedDate != null)
         {
             <br />
             @:You accepted it on @Html.DisplayFor(m => m.Item.CurrentOwnerAcceptedDate, TemplateNames.LongDateTimeOrNotEntered).
         }
-    </p>
+    </div>
 }
 
 @if (Model.Item.IsDeleted) // implies `ComplaintOperation.ManageDeletions`

--- a/src/WebApp/Pages/Admin/Maintenance/ActionTypes/Index.cshtml
+++ b/src/WebApp/Pages/Admin/Maintenance/ActionTypes/Index.cshtml
@@ -10,8 +10,6 @@
     <a asp-page="../Index">← Site Maintenance</a>
 </p>
 
-<partial name="_AlertPartial" for="Message" />
-
 <h1>@IndexModel.ThisOption.PluralName</h1>
 
 <p class="lead">

--- a/src/WebApp/Pages/Admin/Maintenance/ActionTypes/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/ActionTypes/Index.cshtml.cs
@@ -1,7 +1,5 @@
 ﻿using Cts.AppServices.ActionTypes;
 using Cts.AppServices.Permissions;
-using Cts.WebApp.Platform.Models;
-using Cts.WebApp.Platform.PageModelHelpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -13,7 +11,6 @@ public class IndexModel : PageModel
 {
     public IReadOnlyList<ActionTypeViewDto> Items { get; private set; } = default!;
     public static MaintenanceOption ThisOption => MaintenanceOption.ActionType;
-    public DisplayMessage? Message { get; private set; }
     public bool IsSiteMaintainer { get; private set; }
 
     [TempData]
@@ -23,7 +20,6 @@ public class IndexModel : PageModel
         [FromServices] IAuthorizationService authorization)
     {
         Items = await service.GetListAsync();
-        Message = TempData.GetDisplayMessage();
         IsSiteMaintainer = (await authorization.AuthorizeAsync(User, PolicyName.SiteMaintainer)).Succeeded;
     }
 }

--- a/src/WebApp/Pages/Admin/Maintenance/Concerns/Index.cshtml
+++ b/src/WebApp/Pages/Admin/Maintenance/Concerns/Index.cshtml
@@ -10,8 +10,6 @@
     <a asp-page="../Index">← Site Maintenance</a>
 </p>
 
-<partial name="_AlertPartial" for="Message" />
-
 <h1>@IndexModel.ThisOption.PluralName</h1>
 
 <p class="lead">

--- a/src/WebApp/Pages/Admin/Maintenance/Concerns/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Concerns/Index.cshtml.cs
@@ -1,7 +1,5 @@
 ﻿using Cts.AppServices.Concerns;
 using Cts.AppServices.Permissions;
-using Cts.WebApp.Platform.Models;
-using Cts.WebApp.Platform.PageModelHelpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -13,7 +11,6 @@ public class IndexModel : PageModel
 {
     public IReadOnlyList<ConcernViewDto> Items { get; private set; } = default!;
     public static MaintenanceOption ThisOption => MaintenanceOption.Concern;
-    public DisplayMessage? Message { get; private set; }
     public bool IsSiteMaintainer { get; private set; }
 
     [TempData]
@@ -23,7 +20,6 @@ public class IndexModel : PageModel
         [FromServices] IAuthorizationService authorization)
     {
         Items = await service.GetListAsync();
-        Message = TempData.GetDisplayMessage();
         IsSiteMaintainer = (await authorization.AuthorizeAsync(User, PolicyName.SiteMaintainer)).Succeeded;
     }
 }

--- a/src/WebApp/Pages/Admin/Maintenance/Offices/Index.cshtml
+++ b/src/WebApp/Pages/Admin/Maintenance/Offices/Index.cshtml
@@ -10,8 +10,6 @@
     <a asp-page="../Index">← Site Maintenance</a>
 </p>
 
-<partial name="_AlertPartial" for="Message" />
-
 <h1>@IndexModel.ThisOption.PluralName</h1>
 
 <p class="lead">

--- a/src/WebApp/Pages/Admin/Maintenance/Offices/Index.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Maintenance/Offices/Index.cshtml.cs
@@ -1,7 +1,5 @@
 ﻿using Cts.AppServices.Offices;
 using Cts.AppServices.Permissions;
-using Cts.WebApp.Platform.Models;
-using Cts.WebApp.Platform.PageModelHelpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -13,7 +11,6 @@ public class IndexModel : PageModel
 {
     public IReadOnlyList<OfficeAdminViewDto> Items { get; private set; } = default!;
     public static MaintenanceOption ThisOption => MaintenanceOption.Office;
-    public DisplayMessage? Message { get; private set; }
     public bool IsSiteMaintainer { get; private set; }
 
     [TempData]
@@ -23,7 +20,6 @@ public class IndexModel : PageModel
         [FromServices] IAuthorizationService authorization)
     {
         Items = await service.GetListAsync();
-        Message = TempData.GetDisplayMessage();
         IsSiteMaintainer = (await authorization.AuthorizeAsync(User, PolicyName.SiteMaintainer)).Succeeded;
     }
 }

--- a/src/WebApp/Pages/Admin/Users/Details.cshtml
+++ b/src/WebApp/Pages/Admin/Users/Details.cshtml
@@ -8,7 +8,6 @@
 
 <h1>User Profile</h1>
 <hr />
-<partial name="_AlertPartial" for="Message" />
 
 <h2>
     @if (!Model.DisplayStaff.Active)

--- a/src/WebApp/Pages/Admin/Users/Details.cshtml.cs
+++ b/src/WebApp/Pages/Admin/Users/Details.cshtml.cs
@@ -1,8 +1,6 @@
 ﻿using Cts.AppServices.Permissions;
 using Cts.AppServices.Staff;
 using Cts.Domain.Identity;
-using Cts.WebApp.Platform.Models;
-using Cts.WebApp.Platform.PageModelHelpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -15,7 +13,6 @@ public class DetailsModel : PageModel
     public StaffViewDto DisplayStaff { get; private set; } = default!;
     public string? OfficeName => DisplayStaff.Office?.Name;
     public IList<AppRole> Roles { get; private set; } = default!;
-    public DisplayMessage? Message { get; private set; }
     public bool IsUserAdministrator { get; private set; }
 
     public async Task<IActionResult> OnGetAsync(
@@ -29,7 +26,6 @@ public class DetailsModel : PageModel
 
         DisplayStaff = staff;
         Roles = await staffService.GetAppRolesAsync(DisplayStaff.Id);
-        Message = TempData.GetDisplayMessage();
         IsUserAdministrator = (await authorization.AuthorizeAsync(User, PolicyName.UserAdministrator)).Succeeded;
 
         return Page();

--- a/src/WebApp/Pages/Shared/_Layout.cshtml
+++ b/src/WebApp/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,8 @@
-﻿<!DOCTYPE html>
+﻿@using Cts.WebApp.Platform.PageModelHelpers
+@{
+    var displayMessage = TempData.GetDisplayMessage();
+}
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -28,6 +32,7 @@
 
 <div class="container">
     <main id="main-content" role="main" class="pb-3">
+        <partial name="_AlertPartial" for="@displayMessage" />
         @RenderBody()
     </main>
 </div>

--- a/tests/AppServicesTests/ActionTypes/Create.cs
+++ b/tests/AppServicesTests/ActionTypes/Create.cs
@@ -20,7 +20,7 @@ public class Create
         userServiceMock.Setup(l => l.GetCurrentUserAsync())
             .ReturnsAsync((ApplicationUser?)null);
         var appService = new ActionTypeAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.CreateAsync(item.Name);
 

--- a/tests/AppServicesTests/ActionTypes/FindForUpdate.cs
+++ b/tests/AppServicesTests/ActionTypes/FindForUpdate.cs
@@ -18,7 +18,7 @@ public class FindForUpdate
         var managerMock = new Mock<IActionTypeManager>();
         var userServiceMock = new Mock<IUserService>();
         var appService = new ActionTypeAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.FindForUpdateAsync(Guid.Empty);
 

--- a/tests/AppServicesTests/ActionTypes/GetList.cs
+++ b/tests/AppServicesTests/ActionTypes/GetList.cs
@@ -17,7 +17,7 @@ public class GetList
         var managerMock = new Mock<IActionTypeManager>();
         var userServiceMock = new Mock<IUserService>();
         var appService = new ActionTypeAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.GetListAsync();
 

--- a/tests/AppServicesTests/AppServicesTestsSetup.cs
+++ b/tests/AppServicesTests/AppServicesTestsSetup.cs
@@ -1,10 +1,11 @@
 ﻿using AutoMapper;
 using Cts.AppServices.AutoMapper;
+using FluentAssertions.Extensions;
 
 namespace AppServicesTests;
 
 [SetUpFixture]
-public class AppServicesTestsGlobal
+public class AppServicesTestsSetup
 {
     internal static IMapper? Mapper;
     internal static MapperConfiguration? MapperConfig;
@@ -20,6 +21,9 @@ public class AppServicesTestsGlobal
         // See https://fluentassertions.com/objectgraphs/#global-configuration
         // and https://fluentassertions.com/objectgraphs/#matching-members
         AssertionOptions.AssertEquivalencyUsing(opts =>
-            opts.ExcludingMissingMembers());
+            opts.ExcludingMissingMembers()
+                .Using<DateTimeOffset>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Milliseconds()))
+                .WhenTypeIs<DateTimeOffset>()
+        );
     }
 }

--- a/tests/AppServicesTests/AutoMapper/ActionTypeMapping.cs
+++ b/tests/AppServicesTests/AutoMapper/ActionTypeMapping.cs
@@ -12,7 +12,7 @@ public class ActionTypeMapping
     {
         var item = new ActionType(Guid.NewGuid(), "Name");
 
-        var result = AppServicesTestsGlobal.Mapper!.Map<ActionTypeViewDto>(item);
+        var result = AppServicesTestsSetup.Mapper!.Map<ActionTypeViewDto>(item);
 
         using (new AssertionScope())
         {
@@ -27,7 +27,7 @@ public class ActionTypeMapping
     {
         var item = new ActionType(Guid.NewGuid(), "Name");
 
-        var result = AppServicesTestsGlobal.Mapper!.Map<ActionTypeUpdateDto>(item);
+        var result = AppServicesTestsSetup.Mapper!.Map<ActionTypeUpdateDto>(item);
 
         using (new AssertionScope())
         {

--- a/tests/AppServicesTests/AutoMapper/AutoMapperConfiguration.cs
+++ b/tests/AppServicesTests/AutoMapper/AutoMapperConfiguration.cs
@@ -5,6 +5,6 @@ public class AutoMapperConfiguration
     [Test]
     public void MappingConfigurationsAreValid()
     {
-        AppServicesTestsGlobal.MapperConfig!.AssertConfigurationIsValid();
+        AppServicesTestsSetup.MapperConfig!.AssertConfigurationIsValid();
     }
 }

--- a/tests/AppServicesTests/AutoMapper/OfficeMapping.cs
+++ b/tests/AppServicesTests/AutoMapper/OfficeMapping.cs
@@ -13,7 +13,7 @@ public class OfficeMapping
     {
         var item = new Office(Guid.NewGuid(), TestConstants.ValidName);
 
-        var result = AppServicesTestsGlobal.Mapper!.Map<OfficeAdminViewDto>(item);
+        var result = AppServicesTestsSetup.Mapper!.Map<OfficeAdminViewDto>(item);
 
         using (new AssertionScope())
         {
@@ -30,7 +30,7 @@ public class OfficeMapping
         var user = new ApplicationUser { Id = Guid.NewGuid().ToString() };
         var item = new Office(Guid.NewGuid(), TestConstants.ValidName) { Assignor = user };
 
-        var result = AppServicesTestsGlobal.Mapper!.Map<OfficeUpdateDto>(item);
+        var result = AppServicesTestsSetup.Mapper!.Map<OfficeUpdateDto>(item);
 
         using (new AssertionScope())
         {

--- a/tests/AppServicesTests/AutoMapper/UserMapping.cs
+++ b/tests/AppServicesTests/AutoMapper/UserMapping.cs
@@ -21,7 +21,7 @@ public class UserMapping
     [Test]
     public void StaffViewMappingWorks()
     {
-        var result = AppServicesTestsGlobal.Mapper!.Map<StaffViewDto>(_item);
+        var result = AppServicesTestsSetup.Mapper!.Map<StaffViewDto>(_item);
 
         using (new AssertionScope())
         {
@@ -38,7 +38,7 @@ public class UserMapping
     [Test]
     public void StaffUpdateMappingWorks()
     {
-        var result = AppServicesTestsGlobal.Mapper!.Map<StaffUpdateDto>(_item);
+        var result = AppServicesTestsSetup.Mapper!.Map<StaffUpdateDto>(_item);
 
         using (new AssertionScope())
         {
@@ -53,7 +53,7 @@ public class UserMapping
     public void NullStaffViewMappingWorks()
     {
         ApplicationUser? item = null;
-        var result = AppServicesTestsGlobal.Mapper!.Map<StaffViewDto?>(item);
+        var result = AppServicesTestsSetup.Mapper!.Map<StaffViewDto?>(item);
         result.Should().BeNull();
     }
 }

--- a/tests/AppServicesTests/Complaints/Create.cs
+++ b/tests/AppServicesTests/Complaints/Create.cs
@@ -30,7 +30,7 @@ public class Create
 
         var appService = new ComplaintAppService(Mock.Of<IComplaintRepository>(), complaintManagerMock.Object,
             Mock.Of<IConcernRepository>(), officeRepoMock.Object, Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var item = new ComplaintCreateDto { CurrentOfficeId = Guid.Empty };
 
@@ -60,7 +60,7 @@ public class Create
 
         var appService = new ComplaintAppService(Mock.Of<IComplaintRepository>(), complaintManagerMock.Object,
             Mock.Of<IConcernRepository>(), officeRepoMock.Object, Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var item = new ComplaintCreateDto
         {

--- a/tests/AppServicesTests/Complaints/Exists.cs
+++ b/tests/AppServicesTests/Complaints/Exists.cs
@@ -17,7 +17,7 @@ public class Exists
             .ReturnsAsync(true);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.ExistsAsync(0);
 
@@ -32,7 +32,7 @@ public class Exists
             .ReturnsAsync(false);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.ExistsAsync(0);
 

--- a/tests/AppServicesTests/Complaints/Get.cs
+++ b/tests/AppServicesTests/Complaints/Get.cs
@@ -34,7 +34,7 @@ public class Get
             .ReturnsAsync(attachmentList);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetAsync(item.Id);
 
@@ -61,7 +61,7 @@ public class Get
             .ReturnsAsync(attachmentList);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetAsync(item.Id);
 
@@ -76,7 +76,7 @@ public class Get
             .ReturnsAsync((Complaint?)null);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetAsync(0);
 

--- a/tests/AppServicesTests/Complaints/GetAttachment.cs
+++ b/tests/AppServicesTests/Complaints/GetAttachment.cs
@@ -21,7 +21,7 @@ public class GetAttachment
             .ReturnsAsync(item);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetAttachmentAsync(item.Id);
 
@@ -36,7 +36,7 @@ public class GetAttachment
             .ReturnsAsync((Attachment?)null);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetAttachmentAsync(Guid.Empty);
 
@@ -52,7 +52,7 @@ public class GetAttachment
             .ReturnsAsync(item);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetAttachmentAsync(item.Id);
 
@@ -69,7 +69,7 @@ public class GetAttachment
             .ReturnsAsync(item);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetAttachmentAsync(item.Id);
 

--- a/tests/AppServicesTests/Complaints/GetPublic.cs
+++ b/tests/AppServicesTests/Complaints/GetPublic.cs
@@ -34,7 +34,7 @@ public class GetPublic
             .ReturnsAsync(attachmentList);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetPublicAsync(item.Id);
 
@@ -49,7 +49,7 @@ public class GetPublic
             .ReturnsAsync((Complaint?)null);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetPublicAsync(0);
 

--- a/tests/AppServicesTests/Complaints/GetPublicAttachment.cs
+++ b/tests/AppServicesTests/Complaints/GetPublicAttachment.cs
@@ -21,7 +21,7 @@ public class GetPublicAttachment
             .ReturnsAsync(item);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetPublicAttachmentAsync(item.Id);
 
@@ -36,7 +36,7 @@ public class GetPublicAttachment
             .ReturnsAsync((Attachment?)null);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetPublicAttachmentAsync(Guid.Empty);
 
@@ -52,7 +52,7 @@ public class GetPublicAttachment
             .ReturnsAsync(item);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetPublicAttachmentAsync(item.Id);
 
@@ -69,7 +69,7 @@ public class GetPublicAttachment
             .ReturnsAsync(item);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.GetPublicAttachmentAsync(item.Id);
 

--- a/tests/AppServicesTests/Complaints/PublicExists.cs
+++ b/tests/AppServicesTests/Complaints/PublicExists.cs
@@ -19,7 +19,7 @@ public class PublicExists
             .ReturnsAsync(true);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.PublicExistsAsync(0);
 
@@ -35,7 +35,7 @@ public class PublicExists
             .ReturnsAsync(false);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.PublicExistsAsync(0);
 

--- a/tests/AppServicesTests/Complaints/PublicSearch.cs
+++ b/tests/AppServicesTests/Complaints/PublicSearch.cs
@@ -29,7 +29,7 @@ public class PublicSearch
             .ReturnsAsync(count);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
         var result = await appService.PublicSearchAsync(Mock.Of<ComplaintPublicSearchDto>(),
             paging, CancellationToken.None);
 
@@ -56,7 +56,7 @@ public class PublicSearch
             .ReturnsAsync(count);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.PublicSearchAsync(Mock.Of<ComplaintPublicSearchDto>(),
             paging, CancellationToken.None);

--- a/tests/AppServicesTests/Complaints/Search.cs
+++ b/tests/AppServicesTests/Complaints/Search.cs
@@ -29,7 +29,7 @@ public class Search
             .ReturnsAsync(count);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.SearchAsync(Mock.Of<ComplaintSearchDto>(),
             paging, CancellationToken.None);
@@ -56,7 +56,7 @@ public class Search
             .ReturnsAsync(count);
         var appService = new ComplaintAppService(repoMock.Object, Mock.Of<IComplaintManager>(),
             Mock.Of<IConcernRepository>(), Mock.Of<IOfficeRepository>(), Mock.Of<IComplaintTransitionManager>(),
-            AppServicesTestsGlobal.Mapper!, Mock.Of<IUserService>());
+            AppServicesTestsSetup.Mapper!, Mock.Of<IUserService>());
 
         var result = await appService.SearchAsync(Mock.Of<ComplaintSearchDto>(),
             paging, CancellationToken.None);

--- a/tests/AppServicesTests/Concerns/Create.cs
+++ b/tests/AppServicesTests/Concerns/Create.cs
@@ -20,7 +20,7 @@ public class Create
         userServiceMock.Setup(l => l.GetCurrentUserAsync())
             .ReturnsAsync((ApplicationUser?)null);
         var appService = new ConcernAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.CreateAsync(item.Name);
 

--- a/tests/AppServicesTests/Concerns/FindForUpdate.cs
+++ b/tests/AppServicesTests/Concerns/FindForUpdate.cs
@@ -18,7 +18,7 @@ public class FindForUpdate
         var managerMock = new Mock<IConcernManager>();
         var userServiceMock = new Mock<IUserService>();
         var appService = new ConcernAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.FindForUpdateAsync(Guid.Empty);
 

--- a/tests/AppServicesTests/Concerns/GetActiveListItems.cs
+++ b/tests/AppServicesTests/Concerns/GetActiveListItems.cs
@@ -19,7 +19,7 @@ public class GetActiveListItems
         var managerMock = new Mock<IConcernManager>();
         var userServiceMock = new Mock<IUserService>();
         var appService = new ConcernAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.GetActiveListItemsAsync();
 

--- a/tests/AppServicesTests/Concerns/GetList.cs
+++ b/tests/AppServicesTests/Concerns/GetList.cs
@@ -17,7 +17,7 @@ public class GetList
         var managerMock = new Mock<IConcernManager>();
         var userServiceMock = new Mock<IUserService>();
         var appService = new ConcernAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.GetListAsync();
 

--- a/tests/AppServicesTests/Offices/Create.cs
+++ b/tests/AppServicesTests/Offices/Create.cs
@@ -21,7 +21,7 @@ public class Create
         userServiceMock.Setup(l => l.GetCurrentUserAsync())
             .ReturnsAsync((ApplicationUser?)null);
         var appService = new OfficeAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
         var resource = new OfficeCreateDto { Name = TestConstants.ValidName };
 
         var result = await appService.CreateAsync(resource);

--- a/tests/AppServicesTests/Offices/FindForUpdate.cs
+++ b/tests/AppServicesTests/Offices/FindForUpdate.cs
@@ -27,7 +27,7 @@ public class FindForUpdate
         var managerMock = new Mock<IOfficeManager>();
         var userServiceMock = new Mock<IUserService>();
         var appService = new OfficeAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.FindForUpdateAsync(Guid.Empty);
 

--- a/tests/AppServicesTests/Offices/GetList.cs
+++ b/tests/AppServicesTests/Offices/GetList.cs
@@ -28,7 +28,7 @@ public class GetList
         var managerMock = new Mock<IOfficeManager>();
         var userServiceMock = new Mock<IUserService>();
         var appService = new OfficeAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.GetListAsync();
 
@@ -44,7 +44,7 @@ public class GetList
         var managerMock = new Mock<IOfficeManager>();
         var userServiceMock = new Mock<IUserService>();
         var appService = new OfficeAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.GetListAsync();
 

--- a/tests/AppServicesTests/Offices/GetStaff.cs
+++ b/tests/AppServicesTests/Offices/GetStaff.cs
@@ -29,7 +29,7 @@ public class GetStaff
         var userServiceMock = new Mock<IUserService>();
 
         var appService = new OfficeAppService(repoMock.Object, managerMock.Object,
-            AppServicesTestsGlobal.Mapper!, userServiceMock.Object);
+            AppServicesTestsSetup.Mapper!, userServiceMock.Object);
 
         var result = await appService.GetStaffListItemsAsync(Guid.Empty, false);
 

--- a/tests/EfRepositoryTests/EfRepositoryTestsSetup.cs
+++ b/tests/EfRepositoryTests/EfRepositoryTestsSetup.cs
@@ -9,7 +9,7 @@ public class EfRepositoryTestsSetup
     [OneTimeSetUp]
     public void RunBeforeAllTests()
     {
-        AssertionOptions.AssertEquivalencyUsing(options => options
+        AssertionOptions.AssertEquivalencyUsing(opts => opts
             .Using<DateTimeOffset>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Milliseconds()))
             .WhenTypeIs<DateTimeOffset>()
         );
@@ -18,7 +18,7 @@ public class EfRepositoryTestsSetup
     [OneTimeTearDown]
     public void RunAfterAllTests()
     {
-        // Don't leave LocalDB process running (fix test runner warning)
+        // Don't leave LocalDB process running (fixes test runner warning)
         // See https://resharper-support.jetbrains.com/hc/en-us/community/posts/360006736719/comments/360002383960
         using var process = Process.Start("sqllocaldb", "stop MSSQLLocalDB");
         process.WaitForExit();

--- a/tests/WebAppTests/DisplayMessages/DisplayMessageTests.cs
+++ b/tests/WebAppTests/DisplayMessages/DisplayMessageTests.cs
@@ -12,7 +12,7 @@ public class DisplayMessageTests
     {
         // Arrange
         // The actual page model here doesn't matter. DisplayMessage is available for all pages.
-        var page = new ErrorModel(Mock.Of<ILogger<ErrorModel>>()) { TempData = WebAppTestsGlobal.PageTempData() };
+        var page = new ErrorModel(Mock.Of<ILogger<ErrorModel>>()) { TempData = WebAppTestsSetup.PageTempData() };
         var expectedMessage = new DisplayMessage(DisplayMessage.AlertContext.Info, "Info message");
         page.TempData.SetDisplayMessage(expectedMessage.Context, expectedMessage.Message);
 

--- a/tests/WebAppTests/DisplayMessages/DisplayMessageTests.cs
+++ b/tests/WebAppTests/DisplayMessages/DisplayMessageTests.cs
@@ -1,0 +1,25 @@
+﻿using Cts.WebApp.Pages;
+using Cts.WebApp.Platform.Models;
+using Cts.WebApp.Platform.PageModelHelpers;
+using Microsoft.Extensions.Logging;
+
+namespace WebAppTests.DisplayMessages;
+
+public class DisplayMessageTests
+{
+    [Test]
+    public void SetDisplayMessage_ReturnsWithDisplayMessage()
+    {
+        // Arrange
+        // The actual page model here doesn't matter. DisplayMessage is available for all pages.
+        var page = new ErrorModel(Mock.Of<ILogger<ErrorModel>>()) { TempData = WebAppTestsGlobal.PageTempData() };
+        var expectedMessage = new DisplayMessage(DisplayMessage.AlertContext.Info, "Info message");
+        page.TempData.SetDisplayMessage(expectedMessage.Context, expectedMessage.Message);
+
+        // Act
+        page.OnGet(null);
+
+        // Assert
+        page.TempData.GetDisplayMessage().Should().BeEquivalentTo(expectedMessage);
+    }
+}

--- a/tests/WebAppTests/Pages/Account/EditTests.cs
+++ b/tests/WebAppTests/Pages/Account/EditTests.cs
@@ -41,7 +41,7 @@ public class EditTests
         officeService.Setup(l => l.GetActiveListItemsAsync(CancellationToken.None))
             .ReturnsAsync(new List<ListItem>());
         var pageModel = new EditModel(staffService.Object, officeService.Object, Mock.Of<IValidator<StaffUpdateDto>>())
-        { TempData = WebAppTestsGlobal.PageTempData() };
+        { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync();
 
@@ -69,7 +69,7 @@ public class EditTests
         validator.Setup(l => l.ValidateAsync(It.IsAny<StaffUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new EditModel(staffService.Object, Mock.Of<IOfficeAppService>(), validator.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsGlobal.PageTempData() };
+        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 
@@ -94,7 +94,7 @@ public class EditTests
         validator.Setup(l => l.ValidateAsync(It.IsAny<StaffUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new EditModel(staffService.Object, Mock.Of<IOfficeAppService>(), validator.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsGlobal.PageTempData() };
+        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 
@@ -116,7 +116,7 @@ public class EditTests
             .ReturnsAsync(new ValidationResult(validationFailures));
 
         var page = new EditModel(staffService.Object, officeService.Object, validator.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsGlobal.PageTempData() };
+        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 

--- a/tests/WebAppTests/Pages/Admin/Complaints/DetailsTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Complaints/DetailsTests.cs
@@ -35,7 +35,7 @@ public class DetailsTests
                     new[] { ComplaintOperation.ManageDeletions }))
             .ReturnsAsync(AuthorizationResult.Success);
         var page = new DetailsModel(serviceMock.Object, staffServiceMock.Object, authorizationMock.Object)
-            { TempData = WebAppTestsGlobal.PageTempData(), PageContext = WebAppTestsGlobal.PageContextWithUser() };
+            { TempData = WebAppTestsSetup.PageTempData(), PageContext = WebAppTestsSetup.PageContextWithUser() };
 
         await page.OnGetAsync(ItemTest.Id);
 

--- a/tests/WebAppTests/Pages/Admin/Maintenance/ActionTypes/AddTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/ActionTypes/AddTests.cs
@@ -24,7 +24,7 @@ public class AddTests
         var validatorMock = new Mock<IValidator<ActionTypeCreateDto>>();
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<ActionTypeCreateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
-        var page = new AddModel { Item = ItemTest, TempData = WebAppTestsGlobal.PageTempData() };
+        var page = new AddModel { Item = ItemTest, TempData = WebAppTestsSetup.PageTempData() };
         var expectedMessage =
             new DisplayMessage(DisplayMessage.AlertContext.Success, $"“{ItemTest.Name}” successfully added.");
 
@@ -47,7 +47,7 @@ public class AddTests
         var validationFailures = new List<ValidationFailure> { new("property", "message") };
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<ActionTypeCreateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult(validationFailures));
-        var page = new AddModel { Item = ItemTest, TempData = WebAppTestsGlobal.PageTempData() };
+        var page = new AddModel { Item = ItemTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync(serviceMock.Object, validatorMock.Object);
 

--- a/tests/WebAppTests/Pages/Admin/Maintenance/ActionTypes/EditTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/ActionTypes/EditTests.cs
@@ -21,7 +21,7 @@ public class EditTests
         var serviceMock = new Mock<IActionTypeAppService>();
         serviceMock.Setup(l => l.FindForUpdateAsync(ItemTest.Id, CancellationToken.None)).ReturnsAsync(ItemTest);
         var page = new EditModel(serviceMock.Object, Mock.Of<IValidator<ActionTypeUpdateDto>>())
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         await page.OnGetAsync(ItemTest.Id);
 
@@ -38,7 +38,7 @@ public class EditTests
     {
         var serviceMock = new Mock<IActionTypeAppService>();
         var page = new EditModel(serviceMock.Object, Mock.Of<IValidator<ActionTypeUpdateDto>>())
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnGetAsync(null);
 
@@ -56,7 +56,7 @@ public class EditTests
         serviceMock.Setup(l => l.FindForUpdateAsync(It.IsAny<Guid>(), CancellationToken.None))
             .ReturnsAsync((ActionTypeUpdateDto?)null);
         var page = new EditModel(serviceMock.Object, Mock.Of<IValidator<ActionTypeUpdateDto>>())
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnGetAsync(Guid.Empty);
 
@@ -71,7 +71,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<ActionTypeUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new EditModel(serviceMock.Object, validatorMock.Object)
-            { Item = ItemTest, TempData = WebAppTestsGlobal.PageTempData() };
+            { Item = ItemTest, TempData = WebAppTestsSetup.PageTempData() };
         var expectedMessage =
             new DisplayMessage(DisplayMessage.AlertContext.Success, $"“{ItemTest.Name}” successfully updated.");
 
@@ -95,7 +95,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<ActionTypeUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult(validationFailures));
         var page = new EditModel(serviceMock.Object, validatorMock.Object)
-            { Item = ItemTest, TempData = WebAppTestsGlobal.PageTempData() };
+            { Item = ItemTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 

--- a/tests/WebAppTests/Pages/Admin/Maintenance/ActionTypes/IndexTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/ActionTypes/IndexTests.cs
@@ -33,26 +33,8 @@ public class IndexTests
         using (new AssertionScope())
         {
             page.Items.Should().BeEquivalentTo(ListTest);
-            page.Message.Should().BeNull();
+            page.TempData.GetDisplayMessage().Should().BeNull();
             page.HighlightId.Should().BeNull();
         }
-    }
-
-    [Test]
-    public async Task SetDisplayMessage_ReturnsWithDisplayMessage()
-    {
-        var serviceMock = new Mock<IActionTypeAppService>();
-        serviceMock.Setup(l => l.GetListAsync(CancellationToken.None))
-            .ReturnsAsync(ListTest);
-        var authorizationMock = new Mock<IAuthorizationService>();
-        authorizationMock.Setup(l => l.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), null, It.IsAny<string>()))
-            .ReturnsAsync(AuthorizationResult.Success);
-        var page = new IndexModel { TempData = WebAppTestsGlobal.PageTempData() };
-        var expectedMessage = new DisplayMessage(DisplayMessage.AlertContext.Info, "Info message");
-
-        page.TempData.SetDisplayMessage(expectedMessage.Context, expectedMessage.Message);
-        await page.OnGetAsync(serviceMock.Object, authorizationMock.Object);
-
-        page.Message.Should().BeEquivalentTo(expectedMessage);
     }
 }

--- a/tests/WebAppTests/Pages/Admin/Maintenance/ActionTypes/IndexTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/ActionTypes/IndexTests.cs
@@ -24,8 +24,8 @@ public class IndexTests
             .ReturnsAsync(AuthorizationResult.Success);
         var page = new IndexModel
         {
-            TempData = WebAppTestsGlobal.PageTempData(),
-            PageContext = WebAppTestsGlobal.PageContextWithUser(),
+            TempData = WebAppTestsSetup.PageTempData(),
+            PageContext = WebAppTestsSetup.PageContextWithUser(),
         };
 
         await page.OnGetAsync(serviceMock.Object, authorizationMock.Object);

--- a/tests/WebAppTests/Pages/Admin/Maintenance/Offices/AddTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/Offices/AddTests.cs
@@ -30,7 +30,7 @@ public class AddTests
         validator.Setup(l => l.ValidateAsync(It.IsAny<OfficeCreateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new AddModel(serviceMock.Object, staffService.Object, validator.Object)
-            { Item = ItemTest, TempData = WebAppTestsGlobal.PageTempData() };
+            { Item = ItemTest, TempData = WebAppTestsSetup.PageTempData() };
         var expectedMessage =
             new DisplayMessage(DisplayMessage.AlertContext.Success, $"“{ItemTest.Name}” successfully added.");
 
@@ -57,7 +57,7 @@ public class AddTests
         validator.Setup(l => l.ValidateAsync(It.IsAny<OfficeCreateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult(validationFailures));
         var page = new AddModel(serviceMock.Object, staffServiceMock.Object, validator.Object)
-            { Item = ItemTest, TempData = WebAppTestsGlobal.PageTempData() };
+            { Item = ItemTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 

--- a/tests/WebAppTests/Pages/Admin/Maintenance/Offices/EditTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/Offices/EditTests.cs
@@ -26,7 +26,7 @@ public class EditTests
         staffServiceMock.Setup(l => l.GetStaffListItemsAsync(It.IsAny<bool>()))
             .ReturnsAsync(new List<ListItem<string>>());
         var page = new EditModel(serviceMock.Object, staffServiceMock.Object, Mock.Of<IValidator<OfficeUpdateDto>>())
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         await page.OnGetAsync(ItemTest.Id);
 
@@ -46,7 +46,7 @@ public class EditTests
         staffServiceMock.Setup(l => l.GetStaffListItemsAsync(It.IsAny<bool>()))
             .ReturnsAsync(new List<ListItem<string>>());
         var page = new EditModel(serviceMock.Object, staffServiceMock.Object, Mock.Of<IValidator<OfficeUpdateDto>>())
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnGetAsync(null);
 
@@ -67,7 +67,7 @@ public class EditTests
         staffService.Setup(l => l.GetStaffListItemsAsync(It.IsAny<bool>()))
             .ReturnsAsync(new List<ListItem<string>>());
         var page = new EditModel(serviceMock.Object, staffService.Object, Mock.Of<IValidator<OfficeUpdateDto>>())
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnGetAsync(Guid.Empty);
 
@@ -83,7 +83,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<OfficeUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new EditModel(serviceMock.Object, staffServiceMock.Object, validatorMock.Object)
-            { Item = ItemTest, TempData = WebAppTestsGlobal.PageTempData() };
+            { Item = ItemTest, TempData = WebAppTestsSetup.PageTempData() };
         var expectedMessage =
             new DisplayMessage(DisplayMessage.AlertContext.Success, $"“{ItemTest.Name}” successfully updated.");
 
@@ -110,7 +110,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<OfficeUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult(validationFailures));
         var page = new EditModel(serviceMock.Object, staffServiceMock.Object, validatorMock.Object)
-            { Item = ItemTest, TempData = WebAppTestsGlobal.PageTempData() };
+            { Item = ItemTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 

--- a/tests/WebAppTests/Pages/Admin/Maintenance/Offices/IndexTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/Offices/IndexTests.cs
@@ -23,7 +23,7 @@ public class IndexTests
         var authorizationMock = new Mock<IAuthorizationService>();
         authorizationMock.Setup(l => l.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), null, It.IsAny<string>()))
             .ReturnsAsync(AuthorizationResult.Success);
-        var page = new IndexModel { TempData = WebAppTestsGlobal.PageTempData() };
+        var page = new IndexModel { TempData = WebAppTestsSetup.PageTempData() };
 
         await page.OnGetAsync(serviceMock.Object, authorizationMock.Object);
 

--- a/tests/WebAppTests/Pages/Admin/Maintenance/Offices/IndexTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Maintenance/Offices/IndexTests.cs
@@ -30,26 +30,8 @@ public class IndexTests
         using (new AssertionScope())
         {
             page.Items.Should().BeEquivalentTo(ListTest);
-            page.Message.Should().BeNull();
+            page.TempData.GetDisplayMessage().Should().BeNull();
             page.HighlightId.Should().BeNull();
         }
-    }
-
-    [Test]
-    public async Task SetDisplayMessage_ReturnsWithDisplayMessage()
-    {
-        var serviceMock = new Mock<IOfficeAppService>();
-        serviceMock.Setup(l => l.GetListAsync(CancellationToken.None))
-            .ReturnsAsync(ListTest);
-        var authorizationMock = new Mock<IAuthorizationService>();
-        authorizationMock.Setup(l => l.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), null, It.IsAny<string>()))
-            .ReturnsAsync(AuthorizationResult.Success);
-        var page = new IndexModel { TempData = WebAppTestsGlobal.PageTempData() };
-        var expectedMessage = new DisplayMessage(DisplayMessage.AlertContext.Info, "Info message");
-
-        page.TempData.SetDisplayMessage(expectedMessage.Context, expectedMessage.Message);
-        await page.OnGetAsync(serviceMock.Object, authorizationMock.Object);
-
-        page.Message.Should().BeEquivalentTo(expectedMessage);
     }
 }

--- a/tests/WebAppTests/Pages/Admin/Users/DetailsTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/DetailsTests.cs
@@ -39,7 +39,6 @@ public class DetailsTests
             result.Should().BeOfType<PageResult>();
             pageModel.DisplayStaff.Should().Be(staffView);
             pageModel.Roles.Should().BeEmpty();
-            pageModel.Message.Should().BeNull();
         }
     }
 

--- a/tests/WebAppTests/Pages/Admin/Users/DetailsTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/DetailsTests.cs
@@ -30,7 +30,7 @@ public class DetailsTests
         var authorizationMock = new Mock<IAuthorizationService>();
         authorizationMock.Setup(l => l.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), null, It.IsAny<string>()))
             .ReturnsAsync(AuthorizationResult.Success);
-        var pageModel = new DetailsModel { TempData = WebAppTestsGlobal.PageTempData() };
+        var pageModel = new DetailsModel { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(serviceMock.Object, authorizationMock.Object, staffView.Id);
 
@@ -46,7 +46,7 @@ public class DetailsTests
     public async Task OnGet_MissingIdReturnsNotFound()
     {
         var serviceMock = new Mock<IStaffAppService>();
-        var pageModel = new DetailsModel { TempData = WebAppTestsGlobal.PageTempData() };
+        var pageModel = new DetailsModel { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(serviceMock.Object, Mock.Of<IAuthorizationService>(), null);
 
@@ -63,7 +63,7 @@ public class DetailsTests
         var serviceMock = new Mock<IStaffAppService>();
         serviceMock.Setup(l => l.FindAsync(It.IsAny<string>()))
             .ReturnsAsync((StaffViewDto?)null);
-        var pageModel = new DetailsModel { TempData = WebAppTestsGlobal.PageTempData() };
+        var pageModel = new DetailsModel { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel
             .OnGetAsync(serviceMock.Object, Mock.Of<IAuthorizationService>(), Guid.Empty.ToString());

--- a/tests/WebAppTests/Pages/Admin/Users/EditRolesTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/EditRolesTests.cs
@@ -60,7 +60,7 @@ public class EditRolesTests
         authorizationMock.Setup(l => l.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), null, It.IsAny<string>()))
             .ReturnsAsync(AuthorizationResult.Success);
         var pageModel = new EditRolesModel(staffServiceMock.Object, authorizationMock.Object)
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(StaffViewTest.Id);
 
@@ -79,7 +79,7 @@ public class EditRolesTests
     {
         var staffServiceMock = new Mock<IStaffAppService>();
         var pageModel = new EditRolesModel(staffServiceMock.Object, Mock.Of<IAuthorizationService>())
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(null);
 
@@ -97,7 +97,7 @@ public class EditRolesTests
         staffServiceMock.Setup(l => l.FindAsync(It.IsAny<string>()))
             .ReturnsAsync((StaffViewDto?)null);
         var pageModel = new EditRolesModel(staffServiceMock.Object, Mock.Of<IAuthorizationService>())
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(Guid.Empty.ToString());
 
@@ -122,7 +122,7 @@ public class EditRolesTests
         {
             RoleSettings = RoleSettingsTest,
             UserId = Guid.Empty.ToString(),
-            TempData = WebAppTestsGlobal.PageTempData(),
+            TempData = WebAppTestsSetup.PageTempData(),
         };
 
         var result = await page.OnPostAsync();
@@ -152,8 +152,8 @@ public class EditRolesTests
         {
             RoleSettings = RoleSettingsTest,
             UserId = Guid.Empty.ToString(),
-            TempData = WebAppTestsGlobal.PageTempData(),
-            PageContext = WebAppTestsGlobal.PageContextWithUser(),
+            TempData = WebAppTestsSetup.PageTempData(),
+            PageContext = WebAppTestsSetup.PageContextWithUser(),
         };
 
         var result = await page.OnPostAsync();
@@ -178,8 +178,8 @@ public class EditRolesTests
         {
             RoleSettings = RoleSettingsTest,
             UserId = Guid.Empty.ToString(),
-            TempData = WebAppTestsGlobal.PageTempData(),
-            PageContext = WebAppTestsGlobal.PageContextWithUser(),
+            TempData = WebAppTestsSetup.PageTempData(),
+            PageContext = WebAppTestsSetup.PageContextWithUser(),
         };
 
         var result = await page.OnPostAsync();

--- a/tests/WebAppTests/Pages/Admin/Users/EditTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/EditTests.cs
@@ -36,7 +36,7 @@ public class EditTests
         officeServiceMock.Setup(l => l.GetActiveListItemsAsync(CancellationToken.None))
             .ReturnsAsync(new List<ListItem>());
         var pageModel = new EditModel(staffServiceMock.Object, officeServiceMock.Object, Mock.Of<IValidator<StaffUpdateDto>>())
-        { TempData = WebAppTestsGlobal.PageTempData() };
+        { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(StaffViewTest.Id);
 
@@ -54,7 +54,7 @@ public class EditTests
     {
         var pageModel = new EditModel(Mock.Of<IStaffAppService>(),
             Mock.Of<IOfficeAppService>(), Mock.Of<IValidator<StaffUpdateDto>>())
-        { TempData = WebAppTestsGlobal.PageTempData() };
+        { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(null);
 
@@ -73,7 +73,7 @@ public class EditTests
             .ReturnsAsync((StaffViewDto?)null);
         var pageModel = new EditModel(staffServiceMock.Object,
             Mock.Of<IOfficeAppService>(), Mock.Of<IValidator<StaffUpdateDto>>())
-        { TempData = WebAppTestsGlobal.PageTempData() };
+        { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await pageModel.OnGetAsync(Guid.Empty.ToString());
 
@@ -93,7 +93,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<StaffUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new EditModel(staffServiceMock.Object, Mock.Of<IOfficeAppService>(), validatorMock.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsGlobal.PageTempData() };
+        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 
@@ -117,7 +117,7 @@ public class EditTests
         validator.Setup(l => l.ValidateAsync(It.IsAny<StaffUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult());
         var page = new EditModel(staffService.Object, Mock.Of<IOfficeAppService>(), validator.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsGlobal.PageTempData() };
+        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 
@@ -139,7 +139,7 @@ public class EditTests
             .ReturnsAsync(new ValidationResult(validationFailures));
 
         var page = new EditModel(staffServiceMock.Object, officeServiceMock.Object, validatorMock.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsGlobal.PageTempData() };
+        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 
@@ -163,7 +163,7 @@ public class EditTests
         validatorMock.Setup(l => l.ValidateAsync(It.IsAny<StaffUpdateDto>(), CancellationToken.None))
             .ReturnsAsync(new ValidationResult(validationFailures));
         var page = new EditModel(staffServiceMock.Object, Mock.Of<IOfficeAppService>(), validatorMock.Object)
-        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsGlobal.PageTempData() };
+        { UpdateStaff = StaffUpdateTest, TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnPostAsync();
 

--- a/tests/WebAppTests/Pages/Admin/Users/IndexTests.cs
+++ b/tests/WebAppTests/Pages/Admin/Users/IndexTests.cs
@@ -19,7 +19,7 @@ public class IndexTests
         staffServiceMock.Setup(l => l.GetListAsync(It.IsAny<StaffSearchDto>()))
             .ReturnsAsync(new List<StaffViewDto>());
         var page = new IndexModel(officeServiceMock.Object, staffServiceMock.Object)
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
 
         var result = await page.OnGetSearchAsync(new StaffSearchDto());
 
@@ -41,7 +41,7 @@ public class IndexTests
             .ReturnsAsync(new List<ListItem>());
         var staffServiceMock = new Mock<IStaffAppService>();
         var page = new IndexModel(officeServiceMock.Object, staffServiceMock.Object)
-            { TempData = WebAppTestsGlobal.PageTempData() };
+            { TempData = WebAppTestsSetup.PageTempData() };
         page.ModelState.AddModelError("Error", "Sample error description");
 
         var result = await page.OnGetSearchAsync(new StaffSearchDto());

--- a/tests/WebAppTests/WebAppTestsSetup.cs
+++ b/tests/WebAppTests/WebAppTestsSetup.cs
@@ -6,7 +6,7 @@ using System.Security.Claims;
 namespace WebAppTests;
 
 [SetUpFixture]
-public static class WebAppTestsGlobal
+public static class WebAppTestsSetup
 {
     internal static TempDataDictionary PageTempData() =>
         new(new DefaultHttpContext(), Mock.Of<ITempDataProvider>());


### PR DESCRIPTION
No need to have alert/display message code in several Razor pages since it can be included in the Layout file. The only drawback is less flexibility in where in the page the alert gets displayed, but this also improves/enforces display uniformity.