### PR TITLE
Fix public complaint view

### DIFF
--- a/src/WebApp/Pages/Error.cshtml.cs
+++ b/src/WebApp/Pages/Error.cshtml.cs
@@ -15,13 +15,17 @@ public class ErrorModel(ILogger<ErrorModel> logger) : PageModel
 
     public void OnGet(int? statusCode)
     {
-        if (statusCode is null)
+        switch (statusCode)
         {
-            logger.LogError("Error page shown from Get method");
-        }
-        else
-        {
-            logger.LogError("Error page shown from Get method with status code {StatusCode}", statusCode);
+            case null:
+                logger.LogError("Error page shown from Get method");
+                break;
+            case StatusCodes.Status404NotFound:
+                logger.LogWarning("Error page shown from Get method with status code {StatusCode}", statusCode);
+                break;
+            default:
+                logger.LogError("Error page shown from Get method with status code {StatusCode}", statusCode);
+                break;
         }
 
         Status = statusCode;

--- a/src/WebApp/Pages/Public/Complaints/Index.cshtml
+++ b/src/WebApp/Pages/Public/Complaints/Index.cshtml
@@ -90,7 +90,7 @@
         @foreach (var item in Model.Item.ComplaintActions)
         {
             <h3 class="h4 pt-2">
-                @Html.DisplayFor(m => item.ActionDate, DisplayTemplate.LongDate) —
+                @Html.DisplayFor(m => item.ActionDate, DisplayTemplate.DateOnlyOrNotEntered) —
                 <em class="text-brand">@item.ActionTypeName</em>
             </h3>
             <p class="text-break text-pre-line">@item.Comments</p>


### PR DESCRIPTION
Complaints with actions did not display because the view was not updated to accommodate the change to a `DateOnly` data type for action date.