### PR TITLE
Update entity and DTO property attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following settings configure the data stores and authentication for developm
     "UseDevSettings": true,
     "UseInMemoryData": true,
     "UseEfMigrations": false,
+    "DeleteAndRebuildDatabase": true,
     "UseAzureAd": false,
     "LocalUserIsAuthenticated": true,
     "LocalUserIsStaff": true,
@@ -66,7 +67,8 @@ The following settings configure the data stores and authentication for developm
 - *UseInMemoryData*
     - When `true`, the "LocalRepository" project is used for repositories and data stores. Data is initially seeded from the "TestData" project. 
     - When `false`, the "EfRepository" project is used, and a SQL Server database (as specified by the connection string) is created. <small>(If the connection string is missing, then a temporary EF Core in-memory database provider is used. This option is included for convenience and is not recommended.)</small>
-- *UseEfMigrations* — Uses Entity Framework database migrations when `true`. When `false`, the database is deleted and recreated on each run. (Only applies if *UseInMemoryData* is `false`.) The database is seeded with data from the "TestData" project only when `UseEfMigrations` is `false`. Otherwise, the database is left empty.
+- *UseEfMigrations* — Uses Entity Framework database migrations when `true`. When `false`, the `DeleteAndRebuildDatabase` setting controls how the database is handled. (Only applies if *UseInMemoryData* is `false`.)
+- *DeleteAndRebuildDatabase* — When set to `true`, the database is deleted and recreated on each run. When set to `false`, the database is not modified on each run. (Only applies if `UseInMemoryData` and `UseEfMigrations` are both `false`.) If the database does not exist yet, it will not be created if this is set to `false`. The database is seeded with data from the "TestData" project only when `UseEfMigrations` is `false` and `DeleteAndRebuildDatabase` is `true`. Otherwise, the data in the database is not changed.
 - *UseAzureAd* — If `true`, connects to Azure AD for user authentication. (The app must be registered in the Azure portal, and configuration added to the settings file.) If `false`, authentication is simulated using test user data.
 - *LocalUserIsAuthenticated* — Simulates a successful login with a test account when `true`. Simulates a failed login when `false`. (Only applies if *UseAzureAd* is `false`.)
 - *LocalUserIsStaff* — Adds the Staff and Site Maintenance Roles to the logged in account when `true` or no roles when `false`. (Applies whether *UserAzureAd* is `true` or `false`.)

--- a/src/AppServices/Attachments/AttachmentService.cs
+++ b/src/AppServices/Attachments/AttachmentService.cs
@@ -65,16 +65,13 @@ public class AttachmentService(
         attachment.SetDeleted((await userService.GetCurrentUserAsync().ConfigureAwait(false))?.Id);
         await attachmentRepository.UpdateAsync(attachment, token: token).ConfigureAwait(false);
 
-        // FUTURE: Cancellation token should be removed from the `DeleteFileAsync` method.
-#pragma warning disable CA2016
-        // ReSharper disable once MethodSupportsCancellation
-        await fileService.DeleteFileAsync(attachmentView.FileId, ExpandPath(attachmentView.FileId))
-            .ConfigureAwait(false);
+        // Cancellation token in the `DeleteFileAsync` method is only used by the Azure Blob Storage implementation.
+        await fileService.DeleteFileAsync(attachmentView.FileId, ExpandPath(attachmentView.FileId),
+            token).ConfigureAwait(false);
+
         if (attachmentView.IsImage)
-            // ReSharper disable once MethodSupportsCancellation
-            await fileService.DeleteFileAsync(attachmentView.FileId, ExpandPath(attachmentView.FileId, thumbnail: true))
-                .ConfigureAwait(false);
-#pragma warning restore CA2016
+            await fileService.DeleteFileAsync(attachmentView.FileId, ExpandPath(attachmentView.FileId, thumbnail: true),
+                token).ConfigureAwait(false);
     }
 
 

--- a/src/AppServices/Attachments/ValidationAttributes/ValidateFiles.cs
+++ b/src/AppServices/Attachments/ValidationAttributes/ValidateFiles.cs
@@ -72,8 +72,8 @@ public static class ValidateFiles
         { ".xlsx", ZipSignatures },
     };
 
-#pragma warning disable S125
-    // .doc, .xls, .ppt
+#pragma warning disable S125 // Sections of code should not be commented out
+    // In case MS Office files (.doc, .xls, .ppt) are allowed in the future.
     // private static List<byte[]> MsOfficeSignatures { get; } = [[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]];
 #pragma warning restore S125
 }

--- a/src/AppServices/AutoMapper/AutoMapperProfile.cs
+++ b/src/AppServices/AutoMapper/AutoMapperProfile.cs
@@ -1,7 +1,6 @@
 ﻿using AutoMapper;
 using Cts.AppServices.ActionTypes;
 using Cts.AppServices.Attachments.Dto;
-using Cts.AppServices.ComplaintActions;
 using Cts.AppServices.ComplaintActions.Dto;
 using Cts.AppServices.Complaints.CommandDto;
 using Cts.AppServices.Complaints.QueryDto;

--- a/src/AppServices/ComplaintActions/Dto/ActionCreateDto.cs
+++ b/src/AppServices/ComplaintActions/Dto/ActionCreateDto.cs
@@ -19,5 +19,7 @@ public record ActionCreateDto(int ComplaintId)
     public Guid? ActionTypeId { get; init; }
 
     [Required]
+    [DataType(DataType.MultilineText)]
+    [StringLength(10_000)]
     public string Comments { get; init; } = string.Empty;
 }

--- a/src/AppServices/ComplaintActions/Dto/ActionUpdateDto.cs
+++ b/src/AppServices/ComplaintActions/Dto/ActionUpdateDto.cs
@@ -21,5 +21,7 @@ public record ActionUpdateDto
     public Guid? ActionTypeId { get; init; }
 
     [Required]
+    [DataType(DataType.MultilineText)]
+    [StringLength(10_000)]
     public string Comments { get; init; } = string.Empty;
 }

--- a/src/AppServices/Complaints/CommandDto/ComplaintClosureDto.cs
+++ b/src/AppServices/Complaints/CommandDto/ComplaintClosureDto.cs
@@ -1,7 +1,11 @@
-﻿namespace Cts.AppServices.Complaints.CommandDto;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Cts.AppServices.Complaints.CommandDto;
 
 // Used for approving/closing, reopening, deleting, and restoring complaints.
 public record ComplaintClosureDto(int ComplaintId)
 {
+    [DataType(DataType.MultilineText)]
+    [StringLength(7000)]
     public string? Comment { get; init; } = string.Empty;
 }

--- a/src/AppServices/Complaints/CommandDto/ComplaintCreateDto.cs
+++ b/src/AppServices/Complaints/CommandDto/ComplaintCreateDto.cs
@@ -67,14 +67,17 @@ public record ComplaintCreateDto : IComplaintCommandDto
 
     [Required]
     [DataType(DataType.MultilineText)]
+    [StringLength(15_000)]
     [Display(Name = "Nature of Complaint")]
     public string? ComplaintNature { get; init; }
 
     [DataType(DataType.MultilineText)]
+    [StringLength(2000)]
     [Display(Name = "Location of Complaint")]
     public string? ComplaintLocation { get; init; }
 
     [DataType(DataType.MultilineText)]
+    [StringLength(2600)]
     [Display(Name = "Directions to Complaint")]
     public string? ComplaintDirections { get; init; }
 

--- a/src/AppServices/Complaints/CommandDto/ComplaintCreateDto.cs
+++ b/src/AppServices/Complaints/CommandDto/ComplaintCreateDto.cs
@@ -37,9 +37,11 @@ public record ComplaintCreateDto : IComplaintCommandDto
 
     // Caller
 
+    [StringLength(150)]
     [Display(Name = "Name")]
     public string? CallerName { get; init; }
 
+    [StringLength(150)]
     [Display(Name = "Represents")]
     public string? CallerRepresents { get; init; }
 

--- a/src/AppServices/Complaints/CommandDto/ComplaintUpdateDto.cs
+++ b/src/AppServices/Complaints/CommandDto/ComplaintUpdateDto.cs
@@ -66,14 +66,17 @@ public record ComplaintUpdateDto : IComplaintCommandDto
 
     [Required]
     [DataType(DataType.MultilineText)]
+    [StringLength(15_000)]
     [Display(Name = "Nature of Complaint")]
     public string? ComplaintNature { get; init; }
 
     [DataType(DataType.MultilineText)]
+    [StringLength(2000)]
     [Display(Name = "Location of Complaint")]
     public string? ComplaintLocation { get; init; }
 
     [DataType(DataType.MultilineText)]
+    [StringLength(2600)]
     [Display(Name = "Directions to Complaint")]
     public string? ComplaintDirections { get; init; }
 

--- a/src/AppServices/Complaints/CommandDto/ComplaintUpdateDto.cs
+++ b/src/AppServices/Complaints/CommandDto/ComplaintUpdateDto.cs
@@ -36,9 +36,11 @@ public record ComplaintUpdateDto : IComplaintCommandDto
 
     // Caller
 
+    [StringLength(150)]
     [Display(Name = "Name")]
     public string? CallerName { get; init; }
 
+    [StringLength(150)]
     [Display(Name = "Represents")]
     public string? CallerRepresents { get; init; }
 

--- a/src/AppServices/DataExport/DataExportService.cs
+++ b/src/AppServices/DataExport/DataExportService.cs
@@ -1,4 +1,3 @@
-using Cts.AppServices.Utilities;
 using Cts.Domain.DataViews;
 using Cts.Domain.DataViews.DataArchiveViews;
 using GaEpd.FileService;
@@ -23,7 +22,7 @@ public sealed class DataExportService(
             cache.Set(DataExportCacheKey, exportMeta, exportMeta.FileExpirationDate);
         }
 
-        if (await fileService.FileExistsAsync(exportMeta.FileName, exportFilePath, token).ConfigureAwait(false))
+        if (await fileService.FileExistsAsync(exportMeta!.FileName, exportFilePath, token).ConfigureAwait(false))
             return exportMeta;
 
         _ = DeleteOldExportFilesAsync(exportFilePath, token);

--- a/src/AppServices/Permissions/Policies.cs
+++ b/src/AppServices/Permissions/Policies.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace Cts.AppServices.Permissions;
 
-#pragma warning disable S125
+#pragma warning disable S125 // Sections of code should not be commented out
 //
 // Two ways to use these policies:
 //

--- a/src/AppServices/Utilities/FileSize.cs
+++ b/src/AppServices/Utilities/FileSize.cs
@@ -1,25 +1,23 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace Cts.AppServices.Utilities;
+﻿namespace Cts.AppServices.Utilities;
 
 public static class FileSize
 {
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    private enum FileSizeUnits
+    private static string FileSizeUnits(double power) => power switch
     {
-        [UsedImplicitly] bytes = 0,
-        [UsedImplicitly] KB = 1,
-        [UsedImplicitly] MB = 2,
-        [UsedImplicitly] GB = 3,
-        [UsedImplicitly] TB = 4,
-        [UsedImplicitly] PB = 5,
-        [UsedImplicitly] EB = 6,
-    }
+        0 => "bytes",
+        1 => "KB",
+        2 => "MB",
+        3 => "GB",
+        4 => "TB",
+        5 => "PB",
+        6 => "EB",
+        _ => "units",
+    };
 
     public static string ToFileSizeString(long value)
     {
-        var pow = Math.Min(Math.Floor((value > 0 ? Math.Log(value) : 0) / Math.Log(1024)),
-            Enum.GetNames(typeof(FileSizeUnits)).Length); // Total number of FileSizeUnits available
-        return $"{(value / Math.Pow(1024, pow)).ToString(pow == 0 ? "N0" : "N1")} {(FileSizeUnits)(int)pow}";
+        var power = Math.Min(Math.Floor((value > 0 ? Math.Log(value) : 0) / Math.Log(1024)),
+            7); // Total number of FileSizeUnits available
+        return $"{(value / Math.Pow(1024, power)).ToString(power == 0 ? "N0" : "N1")} {FileSizeUnits((int)power)}";
     }
 }

--- a/src/AppServices/Utilities/FileSize.cs
+++ b/src/AppServices/Utilities/FileSize.cs
@@ -16,8 +16,8 @@ public static class FileSize
 
     public static string ToFileSizeString(long value)
     {
-        var power = Math.Min(Math.Floor((value > 0 ? Math.Log(value) : 0) / Math.Log(1024)),
+        var power = Math.Min((int)Math.Floor((value > 0 ? Math.Log(value) : 0) / Math.Log(1024)),
             7); // Total number of FileSizeUnits available
-        return $"{(value / Math.Pow(1024, power)).ToString(power == 0 ? "N0" : "N1")} {FileSizeUnits((int)power)}";
+        return $"{(value / Math.Pow(1024, power)).ToString(power == 0 ? "N0" : "N1")} {FileSizeUnits(power)}";
     }
 }

--- a/src/Domain/Entities/ComplaintActions/ComplaintAction.cs
+++ b/src/Domain/Entities/ComplaintActions/ComplaintAction.cs
@@ -28,6 +28,8 @@ public class ComplaintAction : AuditableSoftDeleteEntity
     [StringLength(100)]
     public string Investigator { get; set; } = string.Empty;
 
+    [DataType(DataType.MultilineText)]
+    [StringLength(10_000)]
     public string Comments { get; set; } = string.Empty;
 
     public DateTimeOffset EnteredDate { get; init; } = DateTimeOffset.Now;

--- a/src/Domain/Entities/ComplaintActions/ComplaintAction.cs
+++ b/src/Domain/Entities/ComplaintActions/ComplaintAction.cs
@@ -28,7 +28,6 @@ public class ComplaintAction : AuditableSoftDeleteEntity
     [StringLength(100)]
     public string Investigator { get; set; } = string.Empty;
 
-    [DataType(DataType.MultilineText)]
     [StringLength(10_000)]
     public string Comments { get; set; } = string.Empty;
 

--- a/src/Domain/Entities/ComplaintTransitions/ComplaintTransition.cs
+++ b/src/Domain/Entities/ComplaintTransitions/ComplaintTransition.cs
@@ -30,7 +30,6 @@ public class ComplaintTransition : AuditableEntity
     public ApplicationUser? TransferredToUser { get; internal set; }
     public Office? TransferredToOffice { get; internal set; }
 
-    [DataType(DataType.MultilineText)]
     [StringLength(7000)]
     public string? Comment { get; internal set; }
 }

--- a/src/Domain/Entities/ComplaintTransitions/ComplaintTransition.cs
+++ b/src/Domain/Entities/ComplaintTransitions/ComplaintTransition.cs
@@ -30,7 +30,8 @@ public class ComplaintTransition : AuditableEntity
     public ApplicationUser? TransferredToUser { get; internal set; }
     public Office? TransferredToOffice { get; internal set; }
 
-    [StringLength(4000)]
+    [DataType(DataType.MultilineText)]
+    [StringLength(7000)]
     public string? Comment { get; internal set; }
 }
 

--- a/src/Domain/Entities/Complaints/Complaint.cs
+++ b/src/Domain/Entities/Complaints/Complaint.cs
@@ -58,10 +58,16 @@ public class Complaint : AuditableSoftDeleteEntity<int>
 
     // Properties: Complaint details
 
+    [DataType(DataType.MultilineText)]
+    [StringLength(15_000)]
     public string? ComplaintNature { get; set; }
 
+    [DataType(DataType.MultilineText)]
+    [StringLength(2000)]
     public string? ComplaintLocation { get; set; }
 
+    [DataType(DataType.MultilineText)]
+    [StringLength(2600)]
     public string? ComplaintDirections { get; set; }
 
     [StringLength(50)]

--- a/src/Domain/Entities/Complaints/Complaint.cs
+++ b/src/Domain/Entities/Complaints/Complaint.cs
@@ -39,8 +39,12 @@ public class Complaint : AuditableSoftDeleteEntity<int>
 
     // Properties: Caller
 
+    [StringLength(150)]
     public string? CallerName { get; set; }
+
+    [StringLength(150)]
     public string? CallerRepresents { get; set; }
+
     public IncompleteAddress? CallerAddress { get; set; }
 
     public PhoneNumber? CallerPhoneNumber { get; set; }

--- a/src/Domain/Entities/Complaints/Complaint.cs
+++ b/src/Domain/Entities/Complaints/Complaint.cs
@@ -58,15 +58,12 @@ public class Complaint : AuditableSoftDeleteEntity<int>
 
     // Properties: Complaint details
 
-    [DataType(DataType.MultilineText)]
     [StringLength(15_000)]
     public string? ComplaintNature { get; set; }
 
-    [DataType(DataType.MultilineText)]
     [StringLength(2000)]
     public string? ComplaintLocation { get; set; }
 
-    [DataType(DataType.MultilineText)]
     [StringLength(2600)]
     public string? ComplaintDirections { get; set; }
 
@@ -125,7 +122,6 @@ public class Complaint : AuditableSoftDeleteEntity<int>
 
     public ApplicationUser? ReviewedBy { get; internal set; }
 
-    [DataType(DataType.MultilineText)]
     [StringLength(7000)]
     public string? ReviewComments { get; internal set; }
 
@@ -137,7 +133,6 @@ public class Complaint : AuditableSoftDeleteEntity<int>
 
     public ApplicationUser? DeletedBy { get; set; }
 
-    [DataType(DataType.MultilineText)]
     [StringLength(7000)]
     public string? DeleteComments { get; set; }
 }

--- a/src/Domain/Entities/Complaints/Complaint.cs
+++ b/src/Domain/Entities/Complaints/Complaint.cs
@@ -115,6 +115,8 @@ public class Complaint : AuditableSoftDeleteEntity<int>
 
     public ApplicationUser? ReviewedBy { get; internal set; }
 
+    [DataType(DataType.MultilineText)]
+    [StringLength(7000)]
     public string? ReviewComments { get; internal set; }
 
     public bool ComplaintClosed { get; internal set; }
@@ -124,6 +126,9 @@ public class Complaint : AuditableSoftDeleteEntity<int>
     // Properties: Deletion
 
     public ApplicationUser? DeletedBy { get; set; }
+
+    [DataType(DataType.MultilineText)]
+    [StringLength(7000)]
     public string? DeleteComments { get; set; }
 }
 

--- a/src/Domain/Identity/ApplicationUser.cs
+++ b/src/Domain/Identity/ApplicationUser.cs
@@ -35,17 +35,20 @@ public class ApplicationUser : IdentityUser, IEntity<string>
     public bool Active { get; set; } = true;
 
     /// <summary>
-    /// "oid: The object identifier for the user in Azure AD. This value is the immutable and non-reusable identifier
-    /// of the user. Use this value, not email, as a unique identifier for users; email addresses can change.
-    /// If you use the Azure AD Graph API in your app, object ID is that value used to query profile information."
-    /// https://learn.microsoft.com/en-us/azure/architecture/multitenant-identity/claims
-    ///
-    /// In ASP.NET Core, the OpenID Connect middleware converts some of the claim types when it populates the
-    /// Claims collection for the user principal:
-    /// oid -> http://schemas.microsoft.com/identity/claims/objectidentifier
+    /// <para><c>oid</c>: The immutable identifier for an object, in this case, a user account. This ID uniquely
+    /// identifies the user across applications - two different applications signing in the same user receives the same
+    /// value in the <c>oid</c> claim. Microsoft Graph returns this ID as the <c>id</c> property for a user account.
+    /// Because the <c>oid</c> allows multiple apps to correlate users, the <c>profile</c> scope is required to receive
+    /// this claim. If a single user exists in multiple tenants, the user contains a different object ID in each
+    /// tenant - they're considered different accounts, even though the user logs into each account with the same
+    /// credentials. The <c>oid</c> claim is a GUID and can't be reused.</para>
+    /// <para>Value comes from the <c>ClaimConstants.ObjectId</c> claim
+    /// (<c>"http://schemas.microsoft.com/identity/claims/objectidentifier</c>").</para>
+    /// <para>ID token claims reference: https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#payload-claims</para>
     /// </summary>
     [PersonalData]
-    public string? AzureAdObjectId { get; set; }
+    [StringLength(36)]
+    public string? AzureAdObjectId { get; init; }
 
     // Display properties
     public string SortableFullName =>

--- a/src/Domain/ValueObjects/PhoneNumber.cs
+++ b/src/Domain/ValueObjects/PhoneNumber.cs
@@ -7,8 +7,6 @@ namespace Cts.Domain.ValueObjects;
 [Owned]
 public record PhoneNumber : ValueObject
 {
-    public int Id { get; init; }
-
     [StringLength(25)]
     [DataType(DataType.PhoneNumber)]
     [Display(Name = "Phone number")]

--- a/src/EfRepository/Contexts/AppDbContext.cs
+++ b/src/EfRepository/Contexts/AppDbContext.cs
@@ -80,11 +80,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbCo
 
         // === Additional configuration ===
 
-#pragma warning disable S125
         // Let's save enums in the database as strings.
-        // See https://stackoverflow.com/a/55260541/212978
-        // builder.Entity<EntityWithEnum>().Property(d => d.MyEnum).HasConversion(new EnumToStringConverter<MyEnumType>());
-#pragma warning restore S125
+        // See https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions?tabs=data-annotations#pre-defined-conversions
+        builder.Entity<Complaint>().Property(complaint => complaint.Status).HasConversion<string>();
+        builder.Entity<ComplaintTransition>().Property(transition => transition.TransitionType).HasConversion<string>();
 
         // ## The following configurations are Sqlite only. ##
         if (Database.ProviderName != SqliteProvider) return;
@@ -93,7 +92,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbCo
         // Sqlite and EF Core are in conflict on how to handle collections of owned types.
         // See: https://stackoverflow.com/a/69826156/212978
         // and: https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types
-        // builder.Entity<EntityWithOwnedType>().OwnsMany(e => e.MyOwnedTypeProperty, b => b.HasKey("Id"));
+        // builder.Entity<EntityWithOwnedTypeCollection>().OwnsMany(e => e.OwnedTypeCollection, b => b.HasKey("Id"));
 #pragma warning restore S125
 
         // "Handling DateTimeOffset in SQLite with Entity Framework Core"

--- a/src/EfRepository/Contexts/AppDbContext.cs
+++ b/src/EfRepository/Contexts/AppDbContext.cs
@@ -88,7 +88,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbCo
         // ## The following configurations are Sqlite only. ##
         if (Database.ProviderName != SqliteProvider) return;
 
-#pragma warning disable S125
+#pragma warning disable S125 // Sections of code should not be commented out
         // Sqlite and EF Core are in conflict on how to handle collections of owned types.
         // See: https://stackoverflow.com/a/69826156/212978
         // and: https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities#collections-of-owned-types

--- a/src/TestData/ComplaintData.cs
+++ b/src/TestData/ComplaintData.cs
@@ -16,6 +16,7 @@ internal static class ComplaintData
             ReceivedDate = DateTimeOffset.Now.AddDays(-4),
             ReceivedBy = UserData.GetUsers.ElementAt(0),
             ComplaintLocation = TextData.ShortMultiline,
+            ComplaintDirections = TextData.Paragraph,
             ComplaintCity = TextData.Word,
             ComplaintCounty = TextData.AnotherWord,
             PrimaryConcern = ConcernData.GetConcerns.ElementAt(0),

--- a/src/TestData/Identity/UserData.cs
+++ b/src/TestData/Identity/UserData.cs
@@ -15,6 +15,7 @@ internal static partial class UserData
             Email = "admin.user@example.net",
             Phone = TextData.ValidPhoneNumber,
             Office = OfficeData.GetOffices.ElementAt(0),
+            AzureAdObjectId = Guid.NewGuid().ToString(),
         },
         new()
         {
@@ -23,6 +24,7 @@ internal static partial class UserData
             FamilyName = "User2",
             Email = "general.user@example.net",
             Office = OfficeData.GetOffices.ElementAt(1),
+            AzureAdObjectId = Guid.NewGuid().ToString(),
         },
         new()
         {
@@ -31,6 +33,7 @@ internal static partial class UserData
             FamilyName = "User3",
             Email = "limited.user@example.net",
             Office = OfficeData.GetOffices.ElementAt(0),
+            AzureAdObjectId = Guid.NewGuid().ToString(),
         },
         new()
         {
@@ -40,6 +43,7 @@ internal static partial class UserData
             Email = "inactive.user@example.net",
             Active = false,
             Office = OfficeData.GetOffices.ElementAt(0),
+            AzureAdObjectId = Guid.NewGuid().ToString(),
         },
     };
 

--- a/src/WebApp/Pages/Staff/ComplaintActions/Index.cshtml
+++ b/src/WebApp/Pages/Staff/ComplaintActions/Index.cshtml
@@ -1,5 +1,4 @@
 @page "{handler?}"
-@using Cts.AppServices.ComplaintActions
 @using Cts.AppServices.ComplaintActions.Dto
 @using Cts.WebApp.Pages.Shared.DisplayTemplates
 @using Cts.WebApp.Platform.PageModelHelpers

--- a/src/WebApp/Pages/Staff/Complaints/DownloadSearch.cshtml.cs
+++ b/src/WebApp/Pages/Staff/Complaints/DownloadSearch.cshtml.cs
@@ -2,7 +2,6 @@
 using Cts.AppServices.Complaints.QueryDto;
 using Cts.AppServices.DataExport;
 using Cts.AppServices.Permissions;
-using Cts.AppServices.Utilities;
 
 namespace Cts.WebApp.Pages.Staff.Complaints;
 

--- a/src/WebApp/Platform/Services/MigratorHostedService.cs
+++ b/src/WebApp/Platform/Services/MigratorHostedService.cs
@@ -38,9 +38,9 @@ public class MigratorHostedService(IServiceProvider serviceProvider, IConfigurat
                 if (!await migrationContext.Roles.AnyAsync(e => e.Name == role, cancellationToken))
                     await roleManager.CreateAsync(new IdentityRole(role));
         }
-        else
+        else if (AppSettings.DevSettings.DeleteAndRebuildDatabase)
         {
-            // Otherwise, delete and re-create the database.
+            // Delete and re-create the database.
             await migrationContext.Database.EnsureDeletedAsync(cancellationToken);
             await migrationContext.Database.EnsureCreatedAsync(cancellationToken);
 

--- a/src/WebApp/Platform/Settings/AppSettings.cs
+++ b/src/WebApp/Platform/Settings/AppSettings.cs
@@ -21,11 +21,13 @@ internal static class AppSettings
     // DEV configuration settings
     public static DevSettingsSection DevSettings { get; set; } = new();
 
+    // PROD configuration settings
     public static readonly DevSettingsSection ProductionDefault = new()
     {
         UseDevSettings = false,
         UseInMemoryData = false,
         UseEfMigrations = true,
+        DeleteAndRebuildDatabase = false,
         UseAzureAd = true,
         LocalUserIsAuthenticated = false,
         LocalUserIsStaff = false,
@@ -46,10 +48,18 @@ internal static class AppSettings
         public bool UseInMemoryData { get; [UsedImplicitly] init; }
 
         /// <summary>
-        /// Uses Entity Framework migrations when `true`. When set to `false`, the database is deleted and
-        /// recreated on each run. (Only applies if <see cref="UseInMemoryData"/> is `false`.)
+        /// Uses Entity Framework migrations when `true`.
+        /// (Only applies if <see cref="UseInMemoryData"/> is `false`.)
         /// </summary>
         public bool UseEfMigrations { get; [UsedImplicitly] init; }
+
+        /// <summary>
+        /// When set to `true`, the database is deleted and recreated on each run. When set to `false`, the database
+        /// is not modified on each run. (If the database does not exist yet, it will not be created if this is set
+        /// to `false`.)
+        /// (Only applies if <see cref="UseInMemoryData"/> and <see cref="UseEfMigrations"/> are both `false`.)
+        /// </summary>
+        public bool DeleteAndRebuildDatabase { get; [UsedImplicitly] init; }
 
         /// <summary>
         /// If `true`, the app must be registered in the Azure portal, and configuration settings added in the

--- a/src/WebApp/appsettings.json
+++ b/src/WebApp/appsettings.json
@@ -37,6 +37,7 @@
     "UseDevSettings": true,
     "UseInMemoryData": true,
     "UseEfMigrations": false,
+    "DeleteAndRebuildDatabase": true,
     "UseAzureAd": false,
     "LocalUserIsAuthenticated": true,
     "LocalUserIsStaff": true,

--- a/tests/AppServicesTests/Utilities/FileSizeTests.cs
+++ b/tests/AppServicesTests/Utilities/FileSizeTests.cs
@@ -5,12 +5,17 @@ namespace AppServicesTests.Utilities;
 public class FileSizeTests
 {
     [Test]
-    [TestCase(0, "0 bytes")]
-    [TestCase(1, "1 bytes")]
-    [TestCase(10, "10 bytes")]
-    [TestCase(1024, "1.0 KB")]
-    [TestCase(2048, "2.0 KB")]
-    [TestCase(99999999, "95.4 MB")]
+    [TestCase(0L, "0 bytes")]
+    [TestCase(1L, "1 bytes")]
+    [TestCase(10L, "10 bytes")]
+    [TestCase(1024L, "1.0 KB")]
+    [TestCase(2048L, "2.0 KB")]
+    [TestCase(99_999_999L, "95.4 MB")]
+    [TestCase(1_073_741_824L, "1.0 GB")]
+    [TestCase(1_099_511_627_776L, "1.0 TB")]
+    [TestCase(1_125_899_906_842_624L, "1.0 PB")]
+    [TestCase(1_152_921_504_606_846_976L, "1.0 EB")]
+    [TestCase(long.MaxValue, "8.0 EB")]
     public void ReturnsCorrectString(long value, string expected)
     {
         FileSize.ToFileSizeString(value).Should().Be(expected);


### PR DESCRIPTION
This PR makes some changes to some entity and DTO properties affecting database and display.

- Enums are saved as strings in the DB.
- Phone number ID is removed.
- A setting is added to recreate or retain the database while debugging.
- Database string column sizes are limited based on current data needs.
- DTO field sizes are limited based on DB column size.
- Other minor code cleanup changes.