### PR TITLE
645 add toc to complaint details pages

### DIFF
--- a/src/WebApp/Pages/Complaint.cshtml
+++ b/src/WebApp/Pages/Complaint.cshtml
@@ -1,4 +1,4 @@
-﻿@page "{id:int?}"
+@page "{id:int?}"
 @using Cts.WebApp.Pages.Shared.DisplayTemplates
 @using Cts.WebApp.Platform.Constants
 @using GaEpd.AppLibrary.Extensions
@@ -44,150 +44,169 @@
     </div>
 }
 
-<h2>Status: <em class="text-info-emphasis">@Model.Item.Status.GetDisplayName()</em></h2>
-
-<div class="container">
-    <dl class="row">
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ReceivedDate)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(model => model.Item.ReceivedDate, DisplayTemplate.LongDateTime)</dd>
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.CurrentOfficeName)</dt>
-        <dd class="col-sm-8 col-lg-9">@Model.Item.CurrentOfficeName</dd>
-    </dl>
-</div>
-
-@if (Model.Item.ComplaintClosed)
-{
-    <div class="container">
-        <dl class="row">
-            <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ComplaintClosedDate)</dt>
-            <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(model => model.Item.ComplaintClosedDate, DisplayTemplate.LongDateTimeOrNotEntered)</dd>
-            <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ReviewComments)</dt>
-            <dd class="col-sm-8 col-lg-9 text-break text-pre-line">@Html.DisplayFor(_ => Model.Item.ReviewComments, DisplayTemplate.StringOrPlaceholder)</dd>
-        </dl>
-    </div>
-}
-
-<h2>Nature of Complaint</h2>
-
-<p class="container text-break text-pre-line">@Html.DisplayFor(_ => Model.Item.ComplaintNature, DisplayTemplate.StringOrPlaceholder)</p>
-
-<div class="container">
-    <dl class="row">
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.PrimaryConcernName)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.PrimaryConcernName, DisplayTemplate.StringOrPlaceholder)</dd>
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SecondaryConcernName)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SecondaryConcernName, DisplayTemplate.StringOrPlaceholder)</dd>
-    </dl>
-</div>
-
-<h2>Complaint Location</h2>
-
-<div class="container">
-    <dl class="row">
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ComplaintLocation)</dt>
-        <dd class="col-sm-8 col-lg-9 text-break text-pre-line">@Html.DisplayFor(_ => Model.Item.ComplaintLocation, DisplayTemplate.StringOrPlaceholder)</dd>
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ComplaintCity)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.ComplaintCity, DisplayTemplate.StringOrPlaceholder)</dd>
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ComplaintCounty)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.ComplaintCounty, DisplayTemplate.County)</dd>
-    </dl>
-</div>
-
-<h2>Source</h2>
-
-<div class="container">
-    <dl class="row">
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SourceFacilityName)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SourceFacilityName, DisplayTemplate.StringOrPlaceholder)</dd>
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SourceFacilityIdNumber)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SourceFacilityIdNumber, DisplayTemplate.StringOrPlaceholder)</dd>
-    </dl>
-</div>
-
-<h2>Source Contact</h2>
-
-<div class="container">
-    <dl class="row">
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SourceContactName)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SourceContactName, DisplayTemplate.StringOrPlaceholder)</dd>
-        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SourceAddress)</dt>
-        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SourceAddress)</dd>
-    </dl>
-</div>
-
-@if (Model.Item.ComplaintClosed)
-{
-    <h2>Actions</h2>
-
-    @if (Model.Item.Actions is { Count: > 0 })
-    {
-        <div class="row row-cols-1 g-3 mb-3">
-            @foreach (var action in Model.Item.Actions)
-            {
-                <div class="col">
-                    <div class="card">
-                        <div class="card-header">
-                            <h3 id="@action.Id.ToString()" class="h5 card-title">
-                                @action.ActionTypeName
-                            </h3>
-                            <h4 class="h5 card-subtitle text-body-secondary">
-                                @Html.DisplayFor(_ => action.ActionDate, DisplayTemplate.DateOnlyOrNotEntered)
-                                @if (!string.IsNullOrWhiteSpace(action.Investigator))
-                                {
-                                    @:by @Html.DisplayFor(_ => action.Investigator)
-                                }
-                            </h4>
-                        </div>
-                        <div class="card-body ">
-                            <div class="text-break text-pre-line">@Html.DisplayFor(_ => action.Comments, DisplayTemplate.StringOrPlaceholder, new { Placeholder = "none" })</div>
-                        </div>
-                    </div>
+<div class="container-full">
+    <div class="row gx-md-3">
+        <div class="col-md-3 mb-3 mb-md-0 d-print-none">
+            <div class="sticky-md-top" id="toc-container">
+                <div class="pb-2 d-grid d-md-none">
+                    <button class="btn btn-outline-primary btn-sm" data-bs-toggle="collapse" data-bs-target="#toc" aria-expanded="false" aria-controls="toc">
+                        On this Page
+                    </button>
                 </div>
+                <h3 class="h5 d-none d-md-block no-anchor">On this Page</h3>
+                <div class="list-group list-group-flush collapse d-md-block" id="toc"></div>
+            </div>
+        </div>
+
+        <div class="col-md-9 order-md-first">
+            <h2>Status: <em class="text-info-emphasis">@Model.Item.Status.GetDisplayName()</em></h2>
+
+            <div class="container">
+                <dl class="row">
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ReceivedDate)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(model => model.Item.ReceivedDate, DisplayTemplate.LongDateTime)</dd>
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.CurrentOfficeName)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Model.Item.CurrentOfficeName</dd>
+
+                    @if (Model.Item.ComplaintClosed)
+                    {
+                        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ComplaintClosedDate)</dt>
+                        <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(model => model.Item.ComplaintClosedDate, DisplayTemplate.LongDateTimeOrNotEntered)</dd>
+                        <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ReviewComments)</dt>
+                        <dd class="col-sm-8 col-lg-9 text-break text-pre-line">@Html.DisplayFor(_ => Model.Item.ReviewComments, DisplayTemplate.StringOrPlaceholder)</dd>
+                    }
+                </dl>
+            </div>
+
+            <h2>Nature of Complaint</h2>
+
+            <p class="container text-break text-pre-line">@Html.DisplayFor(_ => Model.Item.ComplaintNature, DisplayTemplate.StringOrPlaceholder)</p>
+
+            <div class="container">
+                <dl class="row">
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.PrimaryConcernName)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.PrimaryConcernName, DisplayTemplate.StringOrPlaceholder)</dd>
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SecondaryConcernName)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SecondaryConcernName, DisplayTemplate.StringOrPlaceholder)</dd>
+                </dl>
+            </div>
+
+            <h2>Complaint Location</h2>
+
+            <div class="container">
+                <dl class="row">
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ComplaintLocation)</dt>
+                    <dd class="col-sm-8 col-lg-9 text-break text-pre-line">@Html.DisplayFor(_ => Model.Item.ComplaintLocation, DisplayTemplate.StringOrPlaceholder)</dd>
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ComplaintCity)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.ComplaintCity, DisplayTemplate.StringOrPlaceholder)</dd>
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.ComplaintCounty)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.ComplaintCounty, DisplayTemplate.County)</dd>
+                </dl>
+            </div>
+
+            <h2>Source</h2>
+
+            <div class="container">
+                <dl class="row">
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SourceFacilityName)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SourceFacilityName, DisplayTemplate.StringOrPlaceholder)</dd>
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SourceFacilityIdNumber)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SourceFacilityIdNumber, DisplayTemplate.StringOrPlaceholder)</dd>
+                </dl>
+            </div>
+
+            <h2>Source Contact</h2>
+
+            <div class="container">
+                <dl class="row">
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SourceContactName)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SourceContactName, DisplayTemplate.StringOrPlaceholder)</dd>
+                    <dt class="col-sm-4 col-lg-3">@Html.DisplayNameFor(model => model.Item.SourceAddress)</dt>
+                    <dd class="col-sm-8 col-lg-9">@Html.DisplayFor(_ => Model.Item.SourceAddress)</dd>
+                </dl>
+            </div>
+
+            @if (Model.Item.ComplaintClosed)
+            {
+                <h2>Actions</h2>
+
+                @if (Model.Item.Actions is { Count: > 0 })
+                {
+                    <div class="row row-cols-1 g-3 mb-3">
+                        @foreach (var action in Model.Item.Actions)
+                        {
+                            <div class="col">
+                                <div class="card">
+                                    <div class="card-header">
+                                        <h3 id="@action.Id.ToString()" class="h5 card-title">
+                                            @action.ActionTypeName
+                                        </h3>
+                                        <h4 class="h5 card-subtitle text-body-secondary">
+                                            @Html.DisplayFor(_ => action.ActionDate, DisplayTemplate.DateOnlyOrNotEntered)
+                                            @if (!string.IsNullOrWhiteSpace(action.Investigator))
+                                            {
+                                                @:by @Html.DisplayFor(_ => action.Investigator)
+                                            }
+                                        </h4>
+                                    </div>
+                                    <div class="card-body ">
+                                        <div class="text-break text-pre-line">@Html.DisplayFor(_ => action.Comments, DisplayTemplate.StringOrPlaceholder, new { Placeholder = "none" })</div>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <p>
+                        <em>None.</em>
+                    </p>
+                }
+
+                <h2>Attachments</h2>
+
+                <p>
+                    <em>(Attachments may not be available for complaints resolved before April 2018. Please note that not every complaint has attachments.)</em>
+                </p>
+
+                @if (Model.Item.Attachments is { Count: > 0 })
+                {
+                    <table class="table table-hover align-middle" aria-label="File attachments">
+                        <thead>
+                        <tr>
+                            <th scope="col">File</th>
+                            <th scope="col">Size</th>
+                            <th scope="col">Date Uploaded</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var attachment in Model.Item.Attachments)
+                        {
+                            attachment.IsForPublic = true;
+                            <tr>
+                                <td>
+                                    <partial name="Shared/_AttachmentLinkPartial" model="attachment" />
+                                </td>
+                                <td>@Html.DisplayFor(_ => attachment.Size, DisplayTemplate.FileSize)</td>
+                                <td>@Html.DisplayFor(_ => attachment.UploadedDate, DisplayTemplate.ShortDate)</td>
+                            </tr>
+                        }
+                        </tbody>
+                    </table>
+                }
+                else
+                {
+                    <p>
+                        <em>None.</em>
+                    </p>
+                }
             }
         </div>
-    }
-    else
-    {
-        <p>
-            <em>None.</em>
-        </p>
-    }
+    </div>
+</div>
 
-    <h2>Attachments</h2>
-
-    <p>
-        <em>(Attachments may not be available for complaints resolved before April 2018. Please note that not every complaint has attachments.)</em>
-    </p>
-
-    @if (Model.Item.Attachments is { Count: > 0 })
-    {
-        <table class="table table-hover align-middle" aria-label="File attachments">
-            <thead>
-            <tr>
-                <th scope="col">File</th>
-                <th scope="col">Size</th>
-                <th scope="col">Date Uploaded</th>
-            </tr>
-            </thead>
-            <tbody>
-            @foreach (var attachment in Model.Item.Attachments)
-            {
-                attachment.IsForPublic = true;
-                <tr>
-                    <td>
-                        <partial name="Shared/_AttachmentLinkPartial" model="attachment" />
-                    </td>
-                    <td>@Html.DisplayFor(_ => attachment.Size, DisplayTemplate.FileSize)</td>
-                    <td>@Html.DisplayFor(_ => attachment.UploadedDate, DisplayTemplate.ShortDate)</td>
-                </tr>
-            }
-            </tbody>
-        </table>
-    }
-    else
-    {
-        <p>
-            <em>None.</em>
-        </p>
-    }
+@section Scripts
+{
+    <script src="~/js/table-of-contents.js" defer></script>
 }

--- a/src/WebApp/Pages/Staff/Complaints/Details.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Details.cshtml
@@ -16,11 +16,11 @@
             <h1>@ViewData["Title"]</h1>
         </div>
         <div class="col-auto d-print-none ms-2">
-                <a asp-page="/Complaint" asp-route-id="@Model.ComplaintView.Id.ToString()" class="link-offset-2">
-                    <svg class="bi me-2">
-                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-people-fill"></use>
-                    </svg>View public copy
-                </a>
+            <a asp-page="/Complaint" asp-route-id="@Model.ComplaintView.Id.ToString()" class="link-offset-2">
+                <svg class="bi me-2">
+                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-people-fill"></use>
+                </svg>View public copy
+            </a>
         </div>
     </div>
 </div>
@@ -84,6 +84,22 @@
         }
     </div>
 }
+
+<div class="container-full">
+<div class="row gx-md-3">
+<div class="col-md-3 mb-3 mb-md-0 d-print-none">
+    <div class="sticky-md-top" id="toc-container">
+        <div class="pb-2 d-grid d-md-none">
+            <button class="btn btn-outline-primary btn-sm" data-bs-toggle="collapse" data-bs-target="#toc" aria-expanded="false" aria-controls="toc">
+                On this Page
+            </button>
+        </div>
+        <h3 class="h5 d-none d-md-block no-anchor">On this Page</h3>
+        <div class="list-group list-group-flush collapse d-md-block" id="toc"></div>
+    </div>
+</div>
+
+<div class="col-md-9 order-md-first">
 
 <h2 id="status">Status: <em class="text-info-emphasis">@Model.ComplaintView.Status.GetDisplayName()</em></h2>
 
@@ -483,8 +499,12 @@ else
         </div>
     </details>
 }
+</div>
+</div>
+</div>
 
 @section Scripts
 {
+    <script src="~/js/table-of-contents.js" defer></script>
     <partial name="_ValidationScriptsPartial" />
 }

--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -9,6 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <Content Remove="wwwroot\js\table-of-contents.js" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_ContentIncludedByDefault Remove="wwwroot\js\table-of-contents.js" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="LigerShark.WebOptimizer.Core" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
@@ -47,6 +55,7 @@
     <ItemGroup>
         <None Include="../../CHANGELOG.md" />
         <None Include="../../README.md" />
+        <None Include="wwwroot\js\table-of-contents.js" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/WebApp/wwwroot/css/site.css
+++ b/src/WebApp/wwwroot/css/site.css
@@ -358,6 +358,12 @@ label:has([disabled]), label:has(:disabled) {
     margin-bottom: 0;
 }
 
+/* Table of contents
+-------------------------------------------------- */
+#toc-container {
+    top: 2rem;
+}
+
 /* Footer links
 -------------------------------------------------- */
 footer a {

--- a/src/WebApp/wwwroot/js/anchorInit.js
+++ b/src/WebApp/wwwroot/js/anchorInit.js
@@ -2,7 +2,7 @@
 
 const anchors = new AnchorJS();
 // DOMContentLoaded was tested to be the best place to call anchors.add()
-window.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', function () {
     anchors.options.placement = "left";
     // Add anchors to h2, h3, h4, h5, and h6 elements, but exclude any with the "no-anchor" class.
     anchors.add('h2:not(.no-anchor), h3:not(.no-anchor)');

--- a/src/WebApp/wwwroot/js/table-of-contents.js
+++ b/src/WebApp/wwwroot/js/table-of-contents.js
@@ -1,0 +1,18 @@
+﻿document.addEventListener("DOMContentLoaded", function () {
+
+    const toc = document.getElementById('toc');
+    const headers = document.querySelectorAll('h2');
+
+    headers.forEach((header, index) => {
+        //if the h2 does not have an ID, assign one so we can use a tag
+        if (!header.id) {
+            header.id = `section${index + 1}`;
+        }
+
+        const link = document.createElement('a');
+        link.href = `#${header.id}`;
+        link.textContent = header.textContent;
+        link.classList.add('list-group-item', 'list-group-item-action');
+        toc.appendChild(link);
+    });
+});


### PR DESCRIPTION
Added the Table of Contents. Currently looks like this: 
![image](https://github.com/gaepdit/complaint-tracking/assets/99635150/2ed86b74-73a6-4f9c-bee0-16aa1e236f19)

Unsure if we can add the TOC to the side at all times when in fullscreen. Some elements would block the TOC since the whole body is not centralized. See Images below:
![image](https://github.com/gaepdit/complaint-tracking/assets/99635150/363e78a4-5995-4ebc-a88e-87c83d0d4100)
![image](https://github.com/gaepdit/complaint-tracking/assets/99635150/129c384f-62b1-4b80-903d-da152e238b5c)

