### PR TITLE
Prevent caching of modified JS files

### DIFF
--- a/src/WebApp/Pages/Admin/Users/Index.cshtml
+++ b/src/WebApp/Pages/Admin/Users/Index.cshtml
@@ -129,5 +129,5 @@
 }
 
 @section Scripts {
-    <script src="~/js/formSearch.js"></script>
+    <script src="~/js/formSearch.js" asp-append-version="true" ></script>
 }

--- a/src/WebApp/Pages/Index.cshtml
+++ b/src/WebApp/Pages/Index.cshtml
@@ -195,8 +195,8 @@
 }
 
 @section Scripts {
-    <script src="~/js/dateValidation.js"></script>
-    <script src="~/js/formSearch.js"></script>
+    <script src="~/js/dateValidation.js" asp-append-version="true"></script>
+    <script src="~/js/formSearch.js" asp-append-version="true"></script>
     <script>
         document.addEventListener("DOMContentLoaded", function () {
             datePairs(

--- a/src/WebApp/Pages/Shared/_FancyboxScriptsPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_FancyboxScriptsPartial.cshtml
@@ -1,3 +1,3 @@
 ﻿<script src="~/lib/fancybox/jquery.fancybox.min.js"
         integrity="sha512-uURl+ZXMBrF4AwGaWmEetzrd+J5/8NRkWAvJx5sbPSSuOb0bZLqf+tOzniObO00BjHa/dD7gub9oCGMLPQHtQA=="></script>
-<script src="~/js/fancyboxConfig.js"></script>
+<script src="~/js/fancyboxConfig.js" asp-append-version="true"></script>

--- a/src/WebApp/Pages/Shared/_Layout.cshtml
+++ b/src/WebApp/Pages/Shared/_Layout.cshtml
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Complaint Tracking System</title>
     <partial name="_FaviconPartial" />
-    <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.min.css" 
-          integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg=="/>
+    <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.min.css"
+          integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg==" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <partial name="_RaygunScriptsPartial" />
-    <script src="~/js/color-modes.js"></script>
+    <script src="~/js/color-modes.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Styles", false)
 </head>
 
@@ -68,7 +68,7 @@
 {
     <script src="~/lib/anchor-js/anchor.min.js"
             integrity="sha512-byAcNWVEzFfu+tZItctr+WIMUJvpzT2kokkqcBq+VsrM3OrC5Aj9E2gh+hHpU0XNA3wDmX4sDbV5/nkhvTrj4w=="></script>
-    <script src="~/js/anchorInit.js"></script>
+    <script src="~/js/anchorInit.js" asp-append-version="true"></script>
 }
 @await RenderSectionAsync("Scripts", false)
 </body>

--- a/src/WebApp/Pages/Shared/_StaffSelectScriptsPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_StaffSelectScriptsPartial.cshtml
@@ -1,2 +1,2 @@
 ﻿<script src="~/lib/axios/axios.min.js" integrity="sha512-6VJrgykcg/InSIutW2biLwA1Wyq+7bZmMivHw19fI+ycW0jIjsadm8wKQQLlfv3YUS4owfMDlZU38NtaAK6fSg=="></script>
-<script src="~/js/staffSelect.js"></script>
+<script src="~/js/staffSelect.js" asp-append-version="true"></script>

--- a/src/WebApp/Pages/Staff/ComplaintActions/Index.cshtml
+++ b/src/WebApp/Pages/Staff/ComplaintActions/Index.cshtml
@@ -214,8 +214,8 @@
 }
 
 @section Scripts {
-    <script src="~/js/dateValidation.js"></script>
-    <script src="~/js/formSearch.js"></script>
+    <script src="~/js/dateValidation.js" asp-append-version="true" ></script>
+    <script src="~/js/formSearch.js" asp-append-version="true" ></script>
     <script>
         document.addEventListener("DOMContentLoaded", function () {
             datePairs(

--- a/src/WebApp/Pages/Staff/Complaints/Add.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Add.cshtml
@@ -262,9 +262,9 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
-    <script src="~/js/copyContactInfo.js"></script>
+    <script src="~/js/copyContactInfo.js" asp-append-version="true"></script>
     <partial name="_StaffSelectScriptsPartial" />
-    <script src="~/js/fileUpload.js"></script>
+    <script src="~/js/fileUpload.js" asp-append-version="true"></script>
     <script>
         setUpStaffDropdown(
             "@nameof(Model.Item)_@nameof(ComplaintCreateDto.OfficeId)",

--- a/src/WebApp/Pages/Staff/Complaints/Details.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Details.cshtml
@@ -513,7 +513,7 @@ else
 @section Scripts
 {
     <partial name="_ValidationScriptsPartial" />
-    <script src="~/js/fileUpload.js"></script>
+    <script src="~/js/fileUpload.js" asp-append-version="true"></script>
     <script src="~/js/table-of-contents.js" defer></script>
     <partial name="_FancyboxScriptsPartial" />
 }

--- a/src/WebApp/Pages/Staff/Complaints/Edit.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Edit.cshtml
@@ -224,5 +224,5 @@
 @section Scripts
 {
     <partial name="_ValidationScriptsPartial" />
-    <script src="~/js/copyContactInfo.js"></script>
+    <script src="~/js/copyContactInfo.js" asp-append-version="true"></script>
 }

--- a/src/WebApp/Pages/Staff/Complaints/Index.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Index.cshtml
@@ -269,8 +269,8 @@
 }
 
 @section Scripts {
-    <script src="~/js/dateValidation.js"></script>
-    <script src="~/js/formSearch.js"></script>
+    <script src="~/js/dateValidation.js" asp-append-version="true" ></script>
+    <script src="~/js/formSearch.js" asp-append-version="true" ></script>
     <script>
         document.addEventListener("DOMContentLoaded", function () {
             datePairs(


### PR DESCRIPTION
The recent update to the file attachment drag and drop was not working if the browser didn't happen to reload the JS file.