### PR TITLE
Configure HTTP security headers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,8 @@
     <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.2" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
     <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="11.2.2" />
-    <PackageVersion Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.24.0" />
+    <PackageVersion Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.0.0" />
+    <PackageVersion Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="1.0.0" />
     <PackageVersion Include="NunitXml.TestLogger" Version="6.1.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.7.0.110445" />

--- a/src/WebApp/Pages/Admin/Reporting/Export.cshtml
+++ b/src/WebApp/Pages/Admin/Reporting/Export.cshtml
@@ -17,7 +17,7 @@
 {
     <p>Your download should start automatically. Please be patient; it may take several minutes.</p>
     <p>If the download fails, <a asp-page="Export">click here to try again</a>.</p>
-    <script>window.location = "Archive";</script>
+    <script asp-add-content-to-csp>window.location = "Archive";</script>
 }
 else
 {

--- a/src/WebApp/Pages/Index.cshtml
+++ b/src/WebApp/Pages/Index.cshtml
@@ -186,7 +186,7 @@
 @section Scripts {
     <script src="~/js/dateValidation.js"></script>
     <script src="~/js/formSearch.js"></script>
-    <script>
+    <script asp-add-content-to-csp>
         document.addEventListener("DOMContentLoaded", function () {
             datePairs(
                 "Spec_DateFrom",

--- a/src/WebApp/Pages/Shared/_RaygunScriptsPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_RaygunScriptsPartial.cshtml
@@ -7,14 +7,14 @@
     var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "unknown";
 }
 
-<script type="text/javascript">
+<script asp-add-content-to-csp>
   !function(a,b,c,d,e,f,g,h){a.RaygunObject=e,a[e]=a[e]||function(){
   (a[e].o=a[e].o||[]).push(arguments)},f=b.createElement(c),g=b.getElementsByTagName(c)[0],
   f.async=1,f.src=d,g.parentNode.insertBefore(f,g),h=a.onerror,a.onerror=function(b,c,d,f,g){
   h&&h(b,c,d,f,g),g||(g=new Error(b)),a[e].q=a[e].q||[],a[e].q.push({
   e:g})}}(window,document,"script","//cdn.raygun.io/raygun4js/raygun.min.js","rg4js");
 </script>
-<script>
+<script asp-add-nonce>
     rg4js('apiKey', '@apiKey');
     rg4js('setVersion', '@setVersion');
     rg4js('enableCrashReporting', true);
@@ -25,5 +25,5 @@
     }
 </script>
 <environment names="Production">
-    <script>rg4js('enablePulse', true);</script>
+    <script asp-add-content-to-csp>rg4js('enablePulse', true);</script>
 </environment>

--- a/src/WebApp/Pages/Shared/_ValidationScriptsPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_ValidationScriptsPartial.cshtml
@@ -2,7 +2,7 @@
         integrity="sha512-KFHXdr2oObHKI9w4Hv1XPKc898mE4kgYx58oqsc/JqqdLMDI4YjOLzom+EMlW8HFUd0QfjfAvxSL6sEq/a42fQ=="></script>
 <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"
         integrity="sha512-xq+Vm8jC94ynOikewaQXMEkJIOBp7iArs3IhFWSWdRT3Pq8wFz46p+ZDFAR7kHnSFf+zUv52B3prRYnbDRdgog=="></script>
-<script>
+<script asp-add-content-to-csp>
     // Change validation classes to work with Bootstrap
     const settings = {
         validClass: "is-valid",

--- a/src/WebApp/Pages/Staff/ComplaintActions/DownloadSearch.cshtml
+++ b/src/WebApp/Pages/Staff/ComplaintActions/DownloadSearch.cshtml
@@ -22,7 +22,7 @@ else
     </p>
 
     @section Scripts {
-        <script>window.location = document.getElementById("download-link").href;</script>
+        <script asp-add-content-to-csp>window.location = document.getElementById("download-link").href;</script>
     }
 }
 

--- a/src/WebApp/Pages/Staff/ComplaintActions/Index.cshtml
+++ b/src/WebApp/Pages/Staff/ComplaintActions/Index.cshtml
@@ -216,7 +216,7 @@
 @section Scripts {
     <script src="~/js/dateValidation.js"></script>
     <script src="~/js/formSearch.js"></script>
-    <script>
+    <script asp-add-content-to-csp>
         document.addEventListener("DOMContentLoaded", function () {
             datePairs(
                 "Spec_EnteredFrom",

--- a/src/WebApp/Pages/Staff/Complaints/Add.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Add.cshtml
@@ -265,7 +265,7 @@
     <script src="~/js/copyContactInfo.js"></script>
     <partial name="_StaffSelectScriptsPartial" />
     <script src="~/js/fileUpload.js"></script>
-    <script>
+    <script asp-add-content-to-csp>
         setUpStaffDropdown(
             "@nameof(Model.Item)_@nameof(ComplaintCreateDto.OfficeId)",
             "@nameof(Model.Item)_@nameof(ComplaintCreateDto.OwnerId)",

--- a/src/WebApp/Pages/Staff/Complaints/Assign.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Assign.cshtml
@@ -43,7 +43,7 @@
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
 <partial name="_StaffSelectScriptsPartial" />
-    <script>
+    <script asp-add-content-to-csp>
     setUpStaffDropdown(
         "@nameof(Model.ComplaintAssignment)_@nameof(ComplaintAssignmentDto.OfficeId)",
         "@nameof(Model.ComplaintAssignment)_@nameof(ComplaintAssignmentDto.OwnerId)",

--- a/src/WebApp/Pages/Staff/Complaints/DownloadSearch.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/DownloadSearch.cshtml
@@ -22,7 +22,7 @@ else
     </p>
 
     @section Scripts {
-        <script>window.location = document.getElementById("download-link").href;</script>
+        <script asp-add-content-to-csp>window.location = document.getElementById("download-link").href;</script>
     }
 }
 

--- a/src/WebApp/Pages/Staff/Complaints/Index.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Index.cshtml
@@ -271,7 +271,7 @@
 @section Scripts {
     <script src="~/js/dateValidation.js"  ></script>
     <script src="~/js/formSearch.js"  ></script>
-    <script>
+    <script asp-add-content-to-csp>
         document.addEventListener("DOMContentLoaded", function () {
             datePairs(
                 "Spec_ReceivedFrom",

--- a/src/WebApp/Pages/Staff/Complaints/Return.cshtml
+++ b/src/WebApp/Pages/Staff/Complaints/Return.cshtml
@@ -43,7 +43,7 @@
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
     <partial name="_StaffSelectScriptsPartial" />
-    <script>
+    <script asp-add-content-to-csp>
     setUpStaffDropdown(
         "@nameof(Model.ComplaintAssignment)_@nameof(ComplaintAssignmentDto.OfficeId)",
         "@nameof(Model.ComplaintAssignment)_@nameof(ComplaintAssignmentDto.OwnerId)",

--- a/src/WebApp/Pages/_ViewImports.cshtml
+++ b/src/WebApp/Pages/_ViewImports.cshtml
@@ -2,3 +2,4 @@
 @addTagHelper *, WebOptimizer.Core
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, WebApp
+@addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers

--- a/src/WebApp/Platform/AppConfiguration/SecurityHeaders.cs
+++ b/src/WebApp/Platform/AppConfiguration/SecurityHeaders.cs
@@ -4,17 +4,51 @@ namespace Cts.WebApp.Platform.AppConfiguration;
 
 internal static class SecurityHeaders
 {
+    private static readonly string ReportUri =
+        $"https://report-to-api.raygun.com/reports?apikey={AppSettings.RaygunSettings.ApiKey}";
+
     internal static void AddSecurityHeaderPolicies(this HeaderPolicyCollection policies)
     {
-        policies
-            .AddFrameOptionsDeny()
-            .AddXssProtectionBlock()
-            .AddContentTypeOptionsNoSniff()
-            .AddReferrerPolicyStrictOriginWhenCrossOrigin()
-            .RemoveServerHeader();
+        policies.AddFrameOptionsDeny();
+        policies.AddContentTypeOptionsNoSniff();
+        policies.AddReferrerPolicyStrictOriginWhenCrossOrigin();
+        policies.RemoveServerHeader();
+        policies.AddContentSecurityPolicyReportOnly(builder => builder.CspBuilder());
+        policies.AddCrossOriginOpenerPolicy(builder => builder.SameOrigin());
+        policies.AddCrossOriginEmbedderPolicy(builder => builder.Credentialless());
+        policies.AddCrossOriginResourcePolicy(builder => builder.SameSite());
 
-        if (!string.IsNullOrEmpty(AppSettings.RaygunSettings.ApiKey))
-            policies.AddReportingEndpoints(builder => builder.AddEndpoint("csp-endpoint",
-                $"https://report-to-api.raygun.com/reports-csp?apikey={AppSettings.RaygunSettings.ApiKey}"));
+        if (string.IsNullOrEmpty(AppSettings.RaygunSettings.ApiKey)) return;
+        policies.AddReportingEndpoints(builder => builder.AddEndpoint("csp-endpoint", ReportUri));
     }
+
+#pragma warning disable S1075 // "URIs should not be hardcoded"
+    private static void CspBuilder(this CspBuilder builder)
+    {
+        builder.AddDefaultSrc().None();
+        builder.AddBaseUri().None();
+        builder.AddObjectSrc().None();
+        builder.AddScriptSrc().Self()
+            .From("https://cdn.raygun.io/raygun4js/raygun.min.js")
+            .WithHashTagHelper()
+            .WithNonce()
+            .ReportSample();
+        builder.AddStyleSrc().Self()
+            .UnsafeInline()
+            .ReportSample();
+        builder.AddImgSrc().Self().Data();
+        builder.AddConnectSrc()
+            .From("https://api.raygun.com")
+            .From("https://api.raygun.io");
+        builder.AddFontSrc().Self().Data();
+        builder.AddFormAction().Self()
+            .From("https://login.microsoftonline.com");
+        builder.AddManifestSrc().Self();
+        builder.AddFrameAncestors().None();
+
+        if (string.IsNullOrEmpty(AppSettings.RaygunSettings.ApiKey)) return;
+        builder.AddReportUri().To(ReportUri);
+        builder.AddReportTo("csp-endpoint");
+    }
+#pragma warning restore S1075
 }

--- a/src/WebApp/Program.cs
+++ b/src/WebApp/Program.cs
@@ -37,13 +37,10 @@ builder.Services.AddAuthorizationPolicies();
 // Configure UI services.
 builder.Services.AddRazorPages();
 
-// Starting value for HSTS max age is five minutes to allow for debugging.
-// For more info on updating HSTS max age value for production, see:
-// https://gaepdit.github.io/web-apps/use-https.html#how-to-enable-hsts
 if (!builder.Environment.IsDevelopment())
 {
     builder.Services
-        .AddHsts(options => options.MaxAge = TimeSpan.FromMinutes(300))
+        .AddHsts(options => options.MaxAge = TimeSpan.FromDays(360))
         .AddHttpsRedirection(options => options.RedirectStatusCode = StatusCodes.Status308PermanentRedirect);
 }
 

--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
         <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" />
         <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" />
+        <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" />
         <PackageReference Include="Swashbuckle.AspNetCore" />
     </ItemGroup>
 


### PR DESCRIPTION
- Set the HSTS header to one year
- Update the SecurityHeaders package
- Configure the security header and CSP policies (initially set to report only)
- Add CSP tag helpers