### PR TITLE
Update Axios JS library

### DIFF
--- a/src/WebApp/Pages/Admin/Users/Index.cshtml
+++ b/src/WebApp/Pages/Admin/Users/Index.cshtml
@@ -102,7 +102,7 @@
             </tr>
             </thead>
 
-            <tbody class="table-group-divider">
+            <tbody>
             @foreach (var item in Model.SearchResults.Items)
             {
                 <tr class="@(item.Active ? "" : "bg-secondary-subtle")">

--- a/src/WebApp/Pages/Shared/_StaffSelectScriptsPartial.cshtml
+++ b/src/WebApp/Pages/Shared/_StaffSelectScriptsPartial.cshtml
@@ -1,2 +1,3 @@
-﻿<script src="~/lib/axios/axios.min.js" integrity="sha512-6VJrgykcg/InSIutW2biLwA1Wyq+7bZmMivHw19fI+ycW0jIjsadm8wKQQLlfv3YUS4owfMDlZU38NtaAK6fSg=="></script>
+﻿<script src="~/lib/axios/dist/axios.min.js"
+        integrity="sha512-fz5OUhvRocxVANpOJv1PvjjYnR6NfSrk/n6BpF2UfPWuy6PSlQ6aTXp9f4e0vFgDiiNUFC63gtkN5Je7yDjviw=="></script>
 <script src="~/js/staffSelect.js"></script>

--- a/src/WebApp/libman.json
+++ b/src/WebApp/libman.json
@@ -44,13 +44,14 @@
       "destination": "wwwroot/lib/anchor-js/"
     },
     {
-      "library": "axios@1.7.4",
+      "provider": "jsdelivr",
+      "library": "axios@1.13.2",
       "destination": "wwwroot/lib/axios/",
       "files": [
-        "axios.min.js",
-        "axios.js",
-        "axios.js.map",
-        "axios.min.js.map"
+        "dist/axios.min.js",
+        "dist/axios.js",
+        "dist/axios.js.map",
+        "dist/axios.min.js.map"
       ]
     },
     {


### PR DESCRIPTION
Axios version 1.7.4 [is vulnerable](https://security.snyk.io/package/npm/axios/1.7.4).

I updated axios from 1.7.4 to 1.13.2. The latest version is not available at cdnjs, so I changed the provider to jsdelivr. The paths for the installed files have changed (maybe because of the different provider).

Unrelated, I removed an obsolete class from the Users table.