### PR TITLE
Update ImageSharp and other NuGet packages

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
+
+    env:
+      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
     
     steps:
       - name: Check out repository

--- a/.gitignore
+++ b/.gitignore
@@ -555,3 +555,6 @@ coveragereport/
 
 # All JetBrains config files
 .idea/
+
+# SixLabors license file
+sixlabors.lic

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,25 +7,25 @@
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.8" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
-    <PackageVersion Include="Dapper" Version="2.1.72" />
+    <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageVersion Include="GaEpd.AppLibrary" Version="7.2.1" />
-    <PackageVersion Include="GaEpd.EmailService" Version="1.4.2" />
+    <PackageVersion Include="GaEpd.AppLibrary" Version="7.2.2" />
+    <PackageVersion Include="GaEpd.EmailService" Version="1.5.0" />
     <PackageVersion Include="GaEpd.FileService" Version="3.3.2" />
     <PackageVersion Include="HtmlSanitizer" Version="8.0.865" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.477" />
     <PackageVersion Include="MailKit" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.9.0" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
     <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="11.2.5" />
     <PackageVersion Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.3.1" />
@@ -33,15 +33,15 @@
     <PackageVersion Include="NunitXml.TestLogger" Version="8.0.0" />
     <PackageVersion Include="Okta.AspNetCore" Version="5.0.1" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.26.0.140279" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="EfCore.TestSupport" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="ZLogger" Version="2.5.10" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="1.3.1" />
     <PackageVersion Include="NunitXml.TestLogger" Version="8.0.0" />
     <PackageVersion Include="Okta.AspNetCore" Version="5.0.1" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="4.0.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.26.0.140279" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ The solution contains the following projects:
 
 There are also corresponding unit test projects for each (not counting the `TestData` project).
 
+## License requirements
+
+The SixLabors ImageSharp package requires the presence of a license file named `sixlabors.lic` in the `AppServices`
+project directory (`\src\AppServices`). Either retrieve an existing license file for the project
+or [apply for a new one](https://licensing.sixlabors.com/).
+
 ## Development settings
 
 The following settings section configures the data stores, authentication, and other settings for development purposes.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ There are also corresponding unit test projects for each (not counting the `Test
 
 The SixLabors ImageSharp package requires the presence of a license file named `sixlabors.lic` in the `AppServices`
 project directory (`\src\AppServices`). Either retrieve an existing license file for the project
-or [apply for a new one](https://licensing.sixlabors.com/).
+or [apply for a new one](https://licensing.sixlabors.com/). The same license key should be stored as an action secret in
+GitHub.
 
 ## Development settings
 

--- a/src/AppServices/AppServices.csproj
+++ b/src/AppServices/AppServices.csproj
@@ -18,4 +18,8 @@
     <ItemGroup>
         <ProjectReference Include="..\Domain\Domain.csproj" />
     </ItemGroup>
+
+    <PropertyGroup>
+        <SixLaborsLicenseKey>$(SIXLABORS_LICENSE_KEY)</SixLaborsLicenseKey>
+    </PropertyGroup>
 </Project>

--- a/src/WebApp/Platform/Settings/AppSettings.cs
+++ b/src/WebApp/Platform/Settings/AppSettings.cs
@@ -9,8 +9,8 @@ internal static partial class AppSettings
     // Support settings
     public static string? Version { get; private set; }
     public static string? SimpleVersion => Version?.Split('+')[0];
-    
-    public static string Env { get; } = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "unknown";
+
+    private static string Env { get; } = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "unknown";
     public static string ShortEnv => Env switch { "Production" => "prod", "Staging" => "uat", _ => "dev" };
 
     public static Support Support { get; } = new();


### PR DESCRIPTION
The [latest ImageSharp update](https://www.nuget.org/packages/SixLabors.ImageSharp/4.0.0) requires a [build time license key](https://sixlabors.com/posts/licence-enforcement-changes/#what-is-changing%3F) which requires updating GitHub workflows as well.